### PR TITLE
chore: initialize system tests

### DIFF
--- a/system-test/main.test.ts
+++ b/system-test/main.test.ts
@@ -1,0 +1,22 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {assert} from 'chai';
+import {describe, it} from 'mocha';
+
+describe('System test', async () => {
+  it('has a test case', () => {
+      assert.isOk(true);
+  });
+});

--- a/system-test/main.test.ts
+++ b/system-test/main.test.ts
@@ -15,8 +15,8 @@
 import {assert} from 'chai';
 import {describe, it} from 'mocha';
 
-describe('System test', async () => {
+describe('System test', () => {
   it('has a test case', () => {
-      assert.isOk(true);
+    assert.isOk(true);
   });
 });


### PR DESCRIPTION
Added `system-test directory` with a test file so kokoro runs

Fixes #46 
