### PR TITLE
build: do not overwrite hand-written README.md

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -23,4 +23,4 @@ logging.basicConfig(level=logging.DEBUG)
 # Copy common templates
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(source_location='build/src')
-s.copy(templates)
+s.copy(templates, excludes=['README.md'])


### PR DESCRIPTION
We have automated tooling that will overwrite the README every day if we don't add an exclude rule for it.

see: #50 