### PR TITLE
feat(cli): cli interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,22 +164,13 @@ The GitHub commit message. Default value is: `'code suggestions'`.
 *boolean* <br>
 Whether or not to force push a reference with different commit history before the remote reference HEAD. Default value is: `false`.
 
-#### `--files [<file1>...]`
-*string* <br>
-**Required.** A list of files
-
-**Note:** Use either `--files` or `--git-dir` exclusively. Using both with terminate with an error.
-
 #### `--git-dir`
 *string* <br>
 **Required.** The path of a git directory
 
-**Note:** Use either `--files` or `--git-dir` exclusively. Using both with terminate with an error.
-
-
 ### Example
 ```
-code-suggester pr -o 'Foo' -r 'Bar' --git-dir="/my-project"
+code-suggester pr -o foo -r bar -d 'description' -t 'title' -m 'message' --git-dir=.
 ```
 
 ## Supported Node.js Versions

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "engines": {
     "node": ">=8.10.0"
   },
+  "bin": {
+    "code-suggest": "./build/src/bin/code-suggester.js"
+  },
   "repository": "googleapis/code-suggester",
   "main": "build/src/index.js",
   "module": "build/src/index.js",
@@ -39,7 +42,10 @@
   },
   "dependencies": {
     "@octokit/rest": "^18.0.1",
-    "pino": "^6.3.2"
+    "@types/yargs": "^15.0.5",
+    "glob": "^7.1.6",
+    "pino": "^6.3.2",
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/src/bin/code-suggester.ts
+++ b/src/bin/code-suggester.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as yargs from 'yargs';
+import {CREATE_PR_COMMAND, main} from './workflow';
+
+// tslint:disable:no-unused-expression
+// yargs actually is a used expression. TS-lint does not detect it.
+yargs
+  .scriptName('code-suggest')
+  .usage('$0 pr [args]')
+  .command(CREATE_PR_COMMAND, 'Create a new pull request', {
+    'upstream-repo': {
+      alias: 'r',
+      demandOption: true,
+      describe: 'Required. The repository to create the fork off of.',
+      type: 'string',
+    },
+    'upstream-owner': {
+      alias: 'o',
+      demandOption: true,
+      describe: 'Required. The owner of the upstream repository.',
+      type: 'string',
+    },
+    description: {
+      alias: 'd',
+      demandOption: true,
+      describe: 'Required. The GitHub Pull Request description',
+      type: 'string',
+    },
+    title: {
+      alias: 't',
+      demandOption: true,
+      describe: 'Required. The title of the Pull Request.',
+      type: 'string',
+    },
+    branch: {
+      alias: 'b',
+      describe: 'The name of the working branch to apply changes to.',
+      default: 'code-suggestion',
+      type: 'string',
+    },
+    message: {
+      alias: 'm',
+      demandOption: true,
+      describe: 'Required. The GitHub commit message.',
+      type: 'string',
+    },
+    primary: {
+      alias: 'p',
+      describe:
+        "The primary upstream branch to open a Pull Request against. Default is 'master'.",
+      default: 'master',
+      type: 'string',
+    },
+    force: {
+      alias: 'f',
+      describe:
+        'Whether or not to force push the current reference HEAD against the remote reference HEAD. Default is false.',
+      default: false,
+      type: 'boolean',
+    },
+    'maintainers-can-modify': {
+      alias: 'modify',
+      describe:
+        'Whether or not maintainers can modify the pull request. Default is true.',
+      default: true,
+      type: 'boolean',
+    },
+    'git-dir': {
+      describe:
+        'Required. The location of any un-tracked changes that should be made into a pull request. Files in the .gitignore are ignored.',
+      type: 'string',
+      demandOption: true,
+    },
+  })
+  .check(argv => {
+    for (const key in argv) {
+      if (typeof argv[key] === 'string' && !argv[key]) {
+        throw Error(
+          `String parameters cannot be provided empty values. Parameter ${key} was given an empty value`
+        );
+      }
+    }
+    if (argv.files !== undefined && argv['git-dir'] !== undefined) {
+      throw Error('"git-dir" options must be defined');
+    }
+    return true;
+  })
+  .demandCommand(1, 'A minimum of 1 command must be specified')
+  .help().argv;
+
+/**
+ * Parse yargs, get change object, invoke framework-core library!
+ */
+main();

--- a/src/bin/code-suggester.ts
+++ b/src/bin/code-suggester.ts
@@ -95,9 +95,6 @@ yargs
         );
       }
     }
-    if (argv.files !== undefined && argv['git-dir'] !== undefined) {
-      throw Error('"git-dir" options must be defined');
-    }
     return true;
   })
   .demandCommand(1, 'A minimum of 1 command must be specified')

--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -210,7 +210,7 @@ export function getChanges(dir: string): Promise<Changes> {
     validateGitInstalled();
     const absoluteDir = resolvePath(dir);
     const gitRootDir = findRepoRoot(absoluteDir);
-    const diffs: string[] = getAllDiffs(gitRootDir);
+    const diffs = getAllDiffs(gitRootDir);
     return parseChanges(diffs, gitRootDir);
   } catch (err) {
     if (!(err instanceof InstallationError)) {

--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -1,0 +1,167 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {execSync} from 'child_process';
+import {Changes, FileMode, FileData} from '../types';
+import {logger} from '../logger';
+import {readFile} from 'fs';
+import * as path from 'path';
+
+// data about a file in a git directory
+interface GitFileData {
+  path: string;
+  fileData: FileData;
+}
+
+// See https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-git-diff-filesltpatterngt82308203
+type GitDiffStatus = 'A' | 'D' | 'M' | 'T' | 'U' | 'X' | string;
+
+/**
+ * Get the absolute path of a relative path
+ * @param {string} dir the wildcard directory containing git change, not necessarily the root git directory
+ * @returns {string} the absolute path relative to the path that the user executed the bash command in
+ */
+export function resolvePath(dir: string) {
+  const absoluteDir = path.resolve(process.cwd(), dir);
+  return absoluteDir;
+}
+
+/**
+ * Get the git root directory.
+ * @param {string} dir the wildcard directory containing git change, not necessarily the root git directory
+ * @returns {string} the absolute path of the git directory root
+ */
+export function findRepoRoot(dir: string): string {
+  try {
+    return execSync('git rev-parse --show-toplevel', {cwd: dir})
+      .toString()
+      .slice(0, -1); // remove the \n
+  } catch (err) {
+    logger.error(`The directory provided is not a git directory: ${dir}`);
+    throw err;
+  }
+}
+
+/**
+ * Get the GitHub mode, file content, and relative path asynchronously
+ * @param {string} gitRootDir the root of the local GitHub repository
+ * @param {string} gitDiffPattern A single file diff. Renames and copies are broken up into separate diffs. See https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-git-diff-filesltpatterngt82308203 for more details
+ * @returns {GitFileData} the current mode, the relative path of the file in the Git Repository, and the file status.
+ */
+export function getGitFileData(
+  gitRootDir: string,
+  gitDiffPattern: string
+): Promise<GitFileData> {
+  return new Promise((resolve, reject) => {
+    try {
+      const fields: string[] = gitDiffPattern.split(' ');
+      const newMode = fields[1] as FileMode;
+      const oldMode = fields[0].substring(1) as FileMode;
+      const statusAndPath = fields[4].split('\t');
+      const status = statusAndPath[0] as GitDiffStatus;
+      const relativePath = statusAndPath[1];
+      // if file is deleted, do not attempt to read it
+      if (status === 'D') {
+        resolve({path: relativePath, fileData: new FileData(null, oldMode)});
+      } else {
+        // else read the file
+        readFile(
+          gitRootDir + '/' + relativePath,
+          {
+            encoding: 'utf-8',
+          },
+          (err, content) => {
+            if (err) {
+              logger.error(
+                `Error loading file ${relativePath} in git directory ${gitRootDir}`
+              );
+              reject(err);
+            }
+            resolve({
+              path: relativePath,
+              fileData: new FileData(content, newMode),
+            });
+          }
+        );
+      }
+    } catch (err) {
+      logger.warning(
+        `\`git diff --raw\` may have changed formats: \n ${gitDiffPattern}`
+      );
+      reject(err);
+    }
+  });
+}
+
+/**
+ * Get all the diffs using `git diff` of a git directory
+ * @param {string} gitRootDir a git directory
+ * @returns {string[]} a list of git diffs
+ */
+export function getAllDiffs(gitRootDir: string): string[] {
+  execSync('git add -A', {cwd: gitRootDir});
+  const diffs: string[] = execSync('git diff --raw --staged --no-renames', {
+    cwd: gitRootDir,
+  })
+    .toString() // strictly return buffer for mocking purposes. sinon ts doesn't infer {encoding: 'utf-8'}
+    .split('\n'); // remove the trailing new line
+  diffs.pop();
+  return diffs;
+}
+
+/**
+ * Get the git changes of the current project asynchronously.
+ * @param {string[]} diffs the git diff raw output (which only shows relative paths)
+ * @param {string} gitDir the root of the local GitHub repository
+ * @returns {Changes} the changeset
+ */
+export async function parseChanges(
+  diffs: string[],
+  gitDir: string
+): Promise<Changes> {
+  try {
+    // get updated file contents
+    const changes: Changes = new Map();
+    const changePromises: Array<Promise<GitFileData>> = [];
+    for (let i = 0; i < diffs.length; i++) {
+      // TODO - handle memory constraint
+      changePromises.push(getGitFileData(gitDir, diffs[i]));
+    }
+    const gitFileDatas = await Promise.all(changePromises);
+    for (let i = 0; i < gitFileDatas.length; i++) {
+      changes.set(gitFileDatas[i].path, gitFileDatas[i].fileData);
+    }
+    return changes;
+  } catch (err) {
+    logger.error('Error parsing git changes');
+    throw err;
+  }
+}
+
+/**
+ * Load the change set asynchronously
+ * @param dir the directory containing git changes
+ * @returns {Promise<Changes>} the change set
+ */
+export function getChanges(dir: string): Promise<Changes> {
+  try {
+    const absoluteDir = resolvePath(dir);
+    const gitRootDir = findRepoRoot(absoluteDir);
+    const diffs: string[] = getAllDiffs(gitRootDir);
+    return parseChanges(diffs, gitRootDir);
+  } catch (err) {
+    logger.error('Error loadng git changes.');
+    throw err;
+  }
+}

--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -149,8 +149,8 @@ export function getAllDiffs(gitRootDir: string): string[] {
     cwd: gitRootDir,
   })
     .toString() // strictly return buffer for mocking purposes. sinon ts doesn't infer {encoding: 'utf-8'}
+    .trimRight() // remove the trailing new line
     .split('\n');
-  diffs.pop(); // remove the trailing new line
   return diffs;
 }
 

--- a/src/bin/workflow.ts
+++ b/src/bin/workflow.ts
@@ -10,7 +10,7 @@ export const CREATE_PR_COMMAND = 'pr';
 /**
  * map yargs to user pull request otions
  */
-export function setUserCreatePullRequestOptions(): CreatePullRequestUserOptions {
+export function coerceUserCreatePullRequestOptions(): CreatePullRequestUserOptions {
   return {
     upstreamRepo: yargs.argv.upstreamRepo as string,
     upstreamOwner: yargs.argv.upstreamOwner as string,
@@ -30,7 +30,7 @@ export function setUserCreatePullRequestOptions(): CreatePullRequestUserOptions 
 export async function main() {
   try {
     setupLogger();
-    const options = setUserCreatePullRequestOptions();
+    const options = coerceUserCreatePullRequestOptions();
     if (!process.env.ACCESS_TOKEN) {
       throw Error('The ACCESS_TOKEN should not be undefined');
     }

--- a/src/bin/workflow.ts
+++ b/src/bin/workflow.ts
@@ -1,0 +1,52 @@
+import {Changes, CreatePullRequestUserOptions} from '../types';
+import {Octokit} from '@octokit/rest';
+import * as git from './handle-git-dir-change';
+import {createPullRequest} from '../';
+import {logger, setupLogger} from '../logger';
+import * as yargs from 'yargs';
+
+export const CREATE_PR_COMMAND = 'pr';
+
+/**
+ * map yargs to user pull request otions
+ */
+export function setUserCreatePullRequestOptions(): CreatePullRequestUserOptions {
+  return {
+    upstreamRepo: yargs.argv.upstreamRepo as string,
+    upstreamOwner: yargs.argv.upstreamOwner as string,
+    message: yargs.argv.message as string,
+    description: yargs.argv.description as string,
+    title: yargs.argv.title as string,
+    branch: yargs.argv.branch as string,
+    force: yargs.argv.force as boolean,
+    primary: yargs.argv.primary as string,
+    maintainersCanModify: yargs.argv.maintainersCanModify as boolean,
+  };
+}
+
+/**
+ * main workflow entrance
+ */
+export async function main() {
+  try {
+    setupLogger();
+    const options = setUserCreatePullRequestOptions();
+    if (!process.env.ACCESS_TOKEN) {
+      throw Error('The ACCESS_TOKEN should not be undefined');
+    }
+    const octokit = new Octokit({auth: process.env.ACCESS_TOKEN});
+    let changes: Changes;
+    switch (yargs.argv._[0]) {
+      case CREATE_PR_COMMAND:
+        changes = await git.getChanges(yargs.argv['git-dir'] as string);
+        await createPullRequest(octokit, changes, options, logger);
+        break;
+      default:
+        // yargs should have caught this.
+        throw Error(`Unhandled command detected: ${yargs.argv._[0]}`);
+    }
+  } catch (err) {
+    logger.error('Workflow failed');
+    throw err;
+  }
+}

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -1,6 +1,6 @@
 import {describe, it, afterEach} from 'mocha';
 import {assert, expect} from 'chai';
-import {main, setUserCreatePullRequestOptions} from '../src/bin/workflow';
+import {main, coerceUserCreatePullRequestOptions} from '../src/bin/workflow';
 import * as sinon from 'sinon';
 import * as proxyquire from 'proxyquire';
 import * as yargs from 'yargs';
@@ -106,6 +106,6 @@ describe('Mapping pr yargs to create PR options', () => {
 
     sandbox.stub(yargs, 'argv').value({_: ['pr'], ...options});
 
-    expect(setUserCreatePullRequestOptions()).to.deep.equals(options);
+    expect(coerceUserCreatePullRequestOptions()).to.deep.equals(options);
   });
 });

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -1,0 +1,111 @@
+import {describe, it, afterEach} from 'mocha';
+import {assert, expect} from 'chai';
+import {main, setUserCreatePullRequestOptions} from '../src/bin/workflow';
+import * as sinon from 'sinon';
+import * as proxyquire from 'proxyquire';
+import * as yargs from 'yargs';
+
+describe('main', () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('Does not error', async () => {
+    // setup
+    sandbox
+      .stub(process, 'env')
+      .value({...process.env, ACCESS_TOKEN: '123121312'});
+    sandbox
+      .stub(yargs, 'argv')
+      .value({...yargs.argv, _: ['pr'], 'git-dir': 'some/dir'});
+    const stubHelperHandlers = {
+      getChanges: () => {
+        return new Promise(resolve => {
+          resolve(new Map());
+        });
+      },
+    };
+    const stubWorkFlow = proxyquire.noCallThru()('../src/bin/workflow', {
+      './handle-git-dir-change': stubHelperHandlers,
+    });
+    stubWorkFlow.main();
+    assert.isOk(true);
+  });
+  it('fails when there is no env variable', async () => {
+    try {
+      sandbox.stub(process.env, 'ACCESS_TOKEN').value(undefined);
+      await main();
+      assert.fail();
+    } catch (err) {
+      assert.isOk(true);
+    }
+  });
+
+  it('Fails when unrecognized command is given', async () => {
+    // setup
+    sandbox
+      .stub(process, 'env')
+      .value({...process.env, ACCESS_TOKEN: '123121312'});
+    sandbox
+      .stub(yargs, 'argv')
+      .value({...yargs.argv, _: ['pr'], 'git-dir': 'some/dir'});
+    const stubHelperHandlers = {
+      getChanges: () => {
+        return new Promise((resolve, reject) => {
+          reject(Error());
+        });
+      },
+    };
+    const stubWorkFlow = proxyquire.noCallThru()('../src/bin/workflow', {
+      './handle-git-dir-change': stubHelperHandlers,
+    });
+    try {
+      await stubWorkFlow.main();
+      assert.fail();
+    } catch (err) {
+      assert.isOk(true);
+    }
+  });
+
+  it('Passes up the error message when fetching change failed', async () => {
+    // setup
+    sandbox
+      .stub(process, 'env')
+      .value({...process.env, ACCESS_TOKEN: '123121312'});
+    sandbox.stub(yargs, 'argv').value({...yargs.argv, _: ['unrecognized']});
+    try {
+      await main();
+      assert.fail();
+    } catch (err) {
+      assert.isOk(true);
+    }
+  });
+});
+
+describe('Mapping pr yargs to create PR options', () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('Creates', () => {
+    const options = {
+      upstreamRepo: 'foo',
+      upstreamOwner: 'bar',
+      message: 'message',
+      description: 'description',
+      title: 'title',
+      branch: 'branch',
+      force: false,
+      primary: 'primary',
+      maintainersCanModify: true,
+    };
+
+    sandbox.stub(yargs, 'argv').value({_: ['pr'], ...options});
+
+    expect(setUserCreatePullRequestOptions()).to.deep.equals(options);
+  });
+});

--- a/test/fixtures/fixtures
+++ b/test/fixtures/fixtures
@@ -1,0 +1,1 @@
+build/test/fixtures/

--- a/test/fixtures/fixtures
+++ b/test/fixtures/fixtures
@@ -1,1 +1,0 @@
-build/test/fixtures/

--- a/test/git-dir-handler.ts
+++ b/test/git-dir-handler.ts
@@ -32,6 +32,7 @@ before(() => {
 
 // tslint:disable:no-unused-expression
 // .null triggers ts-lint failure, but is valid chai
+// .true triggers ts-lint failure, but is valid chai
 describe('git directory diff output to git file data + content', () => {
   const relativeGitDir = '/fixtures/some/git/dir';
   const absoluteGitDir = process.cwd() + relativeGitDir;
@@ -114,21 +115,25 @@ describe('Repository root', () => {
 });
 
 describe('Path resolving', () => {
-  const absoluteGitDir = process.cwd() + '/test/fixtures';
+  const absoluteGitDirLinux = process.cwd() + '/test/fixtures';
+  const absoluteGitDirDos = process.cwd() + '\\test\\fixtures';
 
   it("Resolves to absolute path when '..' is a prefix", () => {
     const relativeGitDir = '../code-suggester/test/fixtures';
-    expect(resolvePath(relativeGitDir)).equals(absoluteGitDir);
+    const path = resolvePath(relativeGitDir);
+    expect(path === absoluteGitDirLinux || path === absoluteGitDirDos).true;
   });
 
   it("Resolves to absolute path when './' is a prefix", () => {
     const relativeGitDir = './test/fixtures';
-    expect(resolvePath(relativeGitDir)).equals(absoluteGitDir);
+    const path = resolvePath(relativeGitDir);
+    expect(path === absoluteGitDirLinux || path === absoluteGitDirDos).true;
   });
 
   it('Resolves to absolute path when the leading chars are letters', () => {
     const relativeGitDir = 'test/fixtures';
-    expect(resolvePath(relativeGitDir)).equals(absoluteGitDir);
+    const path = resolvePath(relativeGitDir);
+    expect(path === absoluteGitDirLinux || path === absoluteGitDirDos).true;
   });
 });
 

--- a/test/git-dir-handler.ts
+++ b/test/git-dir-handler.ts
@@ -1,0 +1,231 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it, before, afterEach} from 'mocha';
+import {assert, expect} from 'chai';
+import {setup} from './util';
+import {
+  getGitFileData,
+  getAllDiffs,
+  parseChanges,
+  findRepoRoot,
+  resolvePath,
+} from '../src/bin/handle-git-dir-change';
+import * as fs from 'fs';
+import * as sinon from 'sinon';
+import * as child_process from 'child_process';
+
+before(() => {
+  setup();
+});
+
+// tslint:disable:no-unused-expression
+// .null triggers ts-lint failure, but is valid chai
+describe('git directory diff output to git file data + content', () => {
+  const relativeGitDir = '/fixtures/some/git/dir';
+  const absoluteGitDir = process.cwd() + relativeGitDir;
+  const sandbox = sinon.createSandbox();
+  afterEach(() => {
+    // undo all changes
+    sandbox.restore();
+  });
+  it('does not read from a file if the file status is deleted and uses the old mode', async () => {
+    // setup
+    const stubReadFile = sandbox.stub(fs, 'readFile').resolves('Text');
+    const gitDiffTxt = ':100644 000000 8e6c063 0000000 D\tReadme.md';
+    const gitFileData = await getGitFileData(absoluteGitDir, gitDiffTxt);
+    expect(gitFileData.path).equals('Readme.md');
+    expect(gitFileData.fileData.mode).equals('100644');
+    expect(gitFileData.fileData.content).is.null;
+    sinon.assert.notCalled(stubReadFile);
+  });
+  it('gets the new file mode, content and path for created files', async () => {
+    // setup
+    const stubReadFile = sandbox.stub(fs, 'readFile').yields(null, 'Text');
+    const gitDiffTxtAdd = ':000000 100644 0000000 8e6c063 A\tReadme.md';
+    const gitFileDataAdd = await getGitFileData(absoluteGitDir, gitDiffTxtAdd);
+    expect(gitFileDataAdd.fileData.content).equals('Text');
+    expect(gitFileDataAdd.fileData.mode).equals('100644');
+    expect(gitFileDataAdd.path).equals('Readme.md');
+    sinon.assert.calledOnce(stubReadFile);
+  });
+  it('gets the new file mode, content and path for content modified files', async () => {
+    // setup
+    const stubReadFile = sandbox.stub(fs, 'readFile').yields(null, 'new text');
+    const gitDiffTxtModified =
+      ':100644 100644 0000000 8e6c063 M\tmodified/test.txt';
+    const gitFileDataModified = await getGitFileData(
+      absoluteGitDir,
+      gitDiffTxtModified
+    );
+    expect(gitFileDataModified.fileData.content).equals('new text');
+    expect(gitFileDataModified.fileData.mode).equals('100644');
+    expect(gitFileDataModified.path).equals('modified/test.txt');
+    sinon.assert.calledOnce(stubReadFile);
+  });
+
+  it('gets the new file mode, content and path for mode modified files', async () => {
+    // setup
+    const stubReadFile = sandbox
+      .stub(fs, 'readFile')
+      .yields(null, '#!/bin/bash');
+    const gitDiffTxtToExecutable =
+      ':100644 100755 3b18e51 3b18e51 M\tbin/main/test.exe';
+    const gitFileDataTxtToExecutable = await getGitFileData(
+      absoluteGitDir,
+      gitDiffTxtToExecutable
+    );
+    expect(gitFileDataTxtToExecutable.fileData.content).equals('#!/bin/bash');
+    expect(gitFileDataTxtToExecutable.fileData.mode).equals('100755');
+    expect(gitFileDataTxtToExecutable.path).equals('bin/main/test.exe');
+    sinon.assert.calledOnce(stubReadFile);
+  });
+});
+
+describe('Repository root', () => {
+  const dir = '/some/dir';
+  const sandbox = sinon.createSandbox();
+  afterEach(() => {
+    // undo all changes
+    sandbox.restore();
+  });
+  it('Executes the git find root bash command', () => {
+    const stubGitDiff = sandbox
+      .stub(child_process, 'execSync')
+      .returns(Buffer.from(dir));
+    findRepoRoot(dir);
+    sinon.assert.calledOnceWithExactly(
+      stubGitDiff,
+      'git rev-parse --show-toplevel',
+      {cwd: dir}
+    );
+  });
+});
+
+describe('Path resolving', () => {
+  const absoluteGitDir = process.cwd() + '/test/fixtures';
+
+  it("Resolves to absolute path when '..' is a prefix", () => {
+    const relativeGitDir = '../code-suggester/test/fixtures';
+    expect(resolvePath(relativeGitDir)).equals(absoluteGitDir);
+  });
+
+  it("Resolves to absolute path when './' is a prefix", () => {
+    const relativeGitDir = './test/fixtures';
+    expect(resolvePath(relativeGitDir)).equals(absoluteGitDir);
+  });
+
+  it('Resolves to absolute path when the leading chars are letters', () => {
+    const relativeGitDir = 'test/fixtures';
+    expect(resolvePath(relativeGitDir)).equals(absoluteGitDir);
+  });
+});
+
+describe('Finding repository root', () => {
+  const sandbox = sinon.createSandbox();
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('Removes the \\n character', () => {
+    sandbox
+      .stub(child_process, 'execSync')
+      .returns(Buffer.from('/home/user/work\n'));
+    expect(findRepoRoot('home/user/work/subdir')).equals('/home/user/work');
+  });
+
+  it('Rethrows execsync error', () => {
+    sandbox.stub(child_process, 'execSync').throws(Error('Execsync error'));
+    try {
+      findRepoRoot('home/user/work/subdir');
+      assert.fail();
+    } catch (err) {
+      assert.isOk(true);
+      expect(err.message).equals('Execsync error');
+    }
+  });
+});
+
+describe('parse all git diff output', () => {
+  const testDir = process.cwd() + '/fixtures';
+  const sandbox = sinon.createSandbox();
+  afterEach(() => {
+    // undo all changes
+    sandbox.restore();
+  });
+  it('splits file diff into a list and removed \\n', async () => {
+    sandbox
+      .stub(child_process, 'execSync')
+      .returns(
+        Buffer.from(
+          ':000000 100644 0000000 8e6c063 A\tadded.txt\n:100644 000000 8e6c063 0000000 D\tdeleted.txt\n'
+        )
+      );
+    const diffs = getAllDiffs(testDir);
+    expect(diffs[0]).equals(':000000 100644 0000000 8e6c063 A\tadded.txt');
+    expect(diffs[1]).equals(':100644 000000 8e6c063 0000000 D\tdeleted.txt');
+    expect(diffs.length).equals(2);
+  });
+});
+
+describe('parse changes', () => {
+  const testDir = '/test/dir';
+  const sandbox = sinon.createSandbox();
+  const diffs = [
+    ':000000 100644 0000000 8e6c063 A\tadded.txt',
+    ':100644 000000 8e6c063 0000000 D\tdeleted.txt',
+  ];
+  afterEach(() => {
+    // undo all changes
+    sandbox.restore();
+  });
+  it('populates change object with everything from a diff output', async () => {
+    sandbox.stub(fs, 'readFile').yields(null, 'new text');
+    const changes = await parseChanges(diffs, testDir);
+    expect(changes.get('added.txt')?.mode).equals('100644');
+    expect(changes.get('added.txt')?.content).equals('new text');
+    expect(changes.get('deleted.txt')?.mode).equals('100644');
+    expect(changes.get('deleted.txt')?.content).is.null;
+  });
+  it('Passes up the error message with a throw when it is ', async () => {
+    // setup
+    sandbox.stub(fs, 'readFile').throws(Error());
+    try {
+      await parseChanges(diffs, '');
+      assert.fail();
+    } catch (err) {
+      assert.isOk(true);
+    }
+  });
+  it('Passes up the error message with a throw when reading the file fails', async () => {
+    // setup
+    sandbox.stub(fs, 'readFile').yields(Error(), '');
+    try {
+      await parseChanges(diffs, '');
+      assert.fail();
+    } catch (err) {
+      assert.isOk(true);
+    }
+  });
+  it('Passes up the error message with a throw when parsing the diff fails', async () => {
+    // setup
+    try {
+      const badDiff = [':000000 100644 0000000 8e6c063 Aadded.txt'];
+      await parseChanges(badDiff, '');
+      assert.fail();
+    } catch (err) {
+      assert.isOk(true);
+    }
+  });
+});


### PR DESCRIPTION
Create a CLI interface to interact with the framework-core
It:

- takes arguments and maps them to user PR options
- takes a git directory and generates a change set Map from the git diff items
- initializes octokit and a logger
- invokes framework-core
- includes core-logic testing

Closes #35 

Redo of #51