### PR TITLE
feat(git): allow force-push

### DIFF
--- a/src/github-handler/branch-handler.ts
+++ b/src/github-handler/branch-handler.ts
@@ -23,7 +23,7 @@ const DEFAULT_PRIMARY_BRANCH = 'master';
  * Create a new branch reference with the ref prefix
  * @param {string} branchName name of the branch
  */
-function createRef(branchName: string) {
+export function createRef(branchName: string) {
   return REF_PREFIX + branchName;
 }
 
@@ -35,7 +35,7 @@ function createRef(branchName: string) {
  * @param {string} branch the name of the branch
  * @returns {Promise<string>} branch commit HEAD SHA
  */
-async function getBranchHead(
+export async function getBranchHead(
   octokit: Octokit,
   origin: RepoDomain,
   branch: string
@@ -47,10 +47,64 @@ async function getBranchHead(
       branch,
     })
   ).data;
-  logger.info(
-    `Successfully found primary branch HEAD sha "${branchData.commit.sha}".`
-  );
+  logger.info(`Successfully found branch HEAD sha "${branchData.commit.sha}".`);
   return branchData.commit.sha;
+}
+
+/**
+ * Determine if there is a branch with the provided name in the remote GitHub repository
+ * @param {Octokit} octokit The authenticated octokit instance
+ * @param {RepoDomain} remote The domain information of the remote repository
+ * @param {string} name The branch name to create on the repository
+ * @returns {Promise<boolean>} if there is a branch already existing in the remote GitHub repository
+ */
+export async function existsBranchWithName(
+  octokit: Octokit,
+  remote: RepoDomain,
+  name: string
+): Promise<boolean> {
+  const branches = (
+    await octokit.repos.listBranches({
+      owner: remote.owner,
+      repo: remote.repo,
+    })
+  ).data;
+  const match = branches.some(branch => branch.name === name);
+  logger.info(
+    `Existing remote branch ${name} found on ${remote.owner}/${remote.repo}`
+  );
+  return match;
+}
+
+/**
+ * Create a branch on the remote repository if there is not an existing branch
+ * @param {Octokit} octokit The authenticated octokit instance
+ * @param {RepoDomain} remote The domain information of the remote origin repository
+ * @param {string} name The branch name to create on the origin repository
+ * @param {string} baseSha the sha that the base of the reference points to
+ * @param {boolean} duplicate whether there is an existing branch or not
+ * @returns {Promise<void>}
+ */
+export async function createBranch(
+  octokit: Octokit,
+  remote: RepoDomain,
+  name: string,
+  baseSha: string,
+  duplicate: boolean
+): Promise<void> {
+  if (!duplicate) {
+    const refData = (
+      await octokit.git.createRef({
+        owner: remote.owner,
+        repo: remote.repo,
+        ref: createRef(name),
+        sha: baseSha,
+      })
+    ).data;
+    logger.info(`Successfully created branch at ${refData.url}`);
+  } else {
+    logger.info('Skipping branch creation step...');
+  }
 }
 
 /**
@@ -58,33 +112,30 @@ async function getBranchHead(
  * Throws an exception if octokit fails, or if the base branch is invalid
  * @param {Octokit} octokit The authenticated octokit instance
  * @param {RepoDomain} origin The domain information of the remote origin repository
+ * @param {RepoDomain} upstream The domain information of the remote upstream repository
  * @param {string} name The branch name to create on the origin repository
  * @param {string} baseBranch the name of the branch to base the new branch off of. Default is master
  * @returns {Promise<string>} the base SHA for subsequent commits to be based off for the origin branch
  */
-async function branch(
+export async function branch(
   octokit: Octokit,
   origin: RepoDomain,
+  upstream: RepoDomain,
   name: string,
   baseBranch: string = DEFAULT_PRIMARY_BRANCH
 ): Promise<string> {
   // create branch from primary branch HEAD SHA
   try {
-    const baseSHA = await getBranchHead(octokit, origin, baseBranch);
-    const refData = (
-      await octokit.git.createRef({
-        owner: origin.owner,
-        repo: origin.repo,
-        ref: createRef(name),
-        sha: baseSHA,
-      })
-    ).data;
-    logger.info(`Successfully created branch at ${refData.url}`);
-    return baseSHA;
+    const baseSha = await getBranchHead(octokit, upstream, baseBranch);
+    const duplicate: boolean = await existsBranchWithName(
+      octokit,
+      origin,
+      name
+    );
+    await createBranch(octokit, origin, name, baseSha, duplicate);
+    return baseSha;
   } catch (err) {
     logger.error('Error when creating branch');
     throw err;
   }
 }
-
-export {branch, getBranchHead, createRef};

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ async function createPullRequest(
   const refHeadSha: string = await handler.branch(
     octokit,
     origin,
+    upstream,
     originBranch.branch,
     gitHubConfigs.primary
   );
@@ -76,7 +77,8 @@ async function createPullRequest(
     refHeadSha,
     changes,
     originBranch,
-    gitHubConfigs.message
+    gitHubConfigs.message,
+    gitHubConfigs.force
   );
 
   const description: Description = {

--- a/test/commit-and-push.ts
+++ b/test/commit-and-push.ts
@@ -214,13 +214,15 @@ describe('Update branch reference', () => {
     await handler.updateRef(
       octokit,
       {branch: 'test-branch-name', ...origin},
-      sha
+      sha,
+      false
     );
     sandbox.assert.calledOnceWithExactly(stubUpdateRef, {
       owner: origin.owner,
       repo: origin.repo,
       sha,
       ref: 'heads/test-branch-name',
+      force: false,
     });
   });
 });
@@ -285,7 +287,8 @@ describe('Commit and push function', async () => {
       oldHeadSha,
       changes,
       {branch: branchName, ...origin},
-      message
+      message,
+      true
     );
     sandbox.assert.calledOnceWithExactly(stubGetCommit, {
       owner: origin.owner,
@@ -310,6 +313,7 @@ describe('Commit and push function', async () => {
       repo: origin.repo,
       sha: createCommitResponse.data.sha,
       ref: 'heads/test-branch-name',
+      force: true,
     });
   });
   it('Forwards GitHub error if getCommit fails', async () => {

--- a/test/main-make-pr.ts
+++ b/test/main-make-pr.ts
@@ -70,12 +70,15 @@ describe('Make PR main function', () => {
       },
       branch: (
         octokit: Octokit,
-        originBranch: {owner: string; repo: string},
+        origin: {owner: string; repo: string},
+        upstream: {owner: string; repo: string},
         testBranch: string,
         testprimary: string
       ) => {
-        expect(originBranch.owner).equals(originOwner);
-        expect(originBranch.repo).equals(originRepo);
+        expect(origin.owner).equals(originOwner);
+        expect(origin.repo).equals(originRepo);
+        expect(upstream.owner).equals(upstreamOwner);
+        expect(upstream.repo).equals(upstreamRepo);
         expect(testBranch).equals(branch);
         expect(testprimary).equals(primary);
         return oldHeadSha;
@@ -181,12 +184,15 @@ describe('Make PR main function', () => {
       },
       branch: (
         octokit: Octokit,
-        originBranch: {owner: string; repo: string},
+        origin: {owner: string; repo: string},
+        upstream: {owner: string; repo: string},
         testBranch: string,
         testprimary: string
       ) => {
-        expect(originBranch.owner).equals(originOwner);
-        expect(originBranch.repo).equals(originRepo);
+        expect(origin.owner).equals(originOwner);
+        expect(origin.repo).equals(originRepo);
+        expect(upstream.owner).equals(upstreamOwner);
+        expect(upstream.repo).equals(upstreamRepo);
         expect(testBranch).equals(branch);
         expect(testprimary).equals(primary);
         return oldHeadSha;
@@ -221,12 +227,15 @@ describe('Make PR main function', () => {
       },
       branch: (
         octokit: Octokit,
-        originBranch: {owner: string; repo: string},
+        origin: {owner: string; repo: string},
+        upstream: {owner: string; repo: string},
         testBranch: string,
         testprimary: string
       ) => {
-        expect(originBranch.owner).equals(originOwner);
-        expect(originBranch.repo).equals(originRepo);
+        expect(origin.owner).equals(originOwner);
+        expect(origin.repo).equals(originRepo);
+        expect(upstream.owner).equals(upstreamOwner);
+        expect(upstream.repo).equals(upstreamRepo);
         expect(testBranch).equals(branch);
         expect(testprimary).equals(primary);
         return oldHeadSha;


### PR DESCRIPTION
Behaviour: when a change set is given, a commit is created with the change set applied on top of the latest upstream remote primary branch. If there is an existing branch diverging in commit history, it will be erased.

Also, if a branch exists already, no need to create a new branch.

Always return the latest upstream master sha to base future commits off of.

Towards #17 
