### PR TITLE
fix(cli,action): when process fails, make exit code 1

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-code-suggester $INPUT_COMMAND \
+if code-suggester $INPUT_COMMAND \
 --upstream-repo="$INPUT_UPSTREAM_REPO" \
 --upstream-owner="$INPUT_UPSTREAM_OWNER" \
 --description="$INPUT_DESCRIPTION" \
@@ -24,4 +24,8 @@ code-suggester $INPUT_COMMAND \
 --message="$INPUT_MESSAGE" \
 --force="$INPUT_FORCE" \
 --maintainers-can-modify="$INPUT_MAINTAINERS_CAN_MODIFY" \
---git-dir="$INPUT_GIT_DIR"
+--git-dir="$INPUT_GIT_DIR"; then
+    exit 0
+else
+    exit 1
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if code-suggester $INPUT_COMMAND \
+set -e
+
+code-suggester $INPUT_COMMAND \
 --upstream-repo="$INPUT_UPSTREAM_REPO" \
 --upstream-owner="$INPUT_UPSTREAM_OWNER" \
 --description="$INPUT_DESCRIPTION" \
@@ -24,8 +26,4 @@ if code-suggester $INPUT_COMMAND \
 --message="$INPUT_MESSAGE" \
 --force="$INPUT_FORCE" \
 --maintainers-can-modify="$INPUT_MAINTAINERS_CAN_MODIFY" \
---git-dir="$INPUT_GIT_DIR"; then
-    exit 0
-else
-    exit 1
-fi
+--git-dir="$INPUT_GIT_DIR"

--- a/src/bin/code-suggester.ts
+++ b/src/bin/code-suggester.ts
@@ -103,4 +103,4 @@ yargs
 /**
  * Parse yargs, get change object, invoke framework-core library!
  */
-main();
+main().catch(() => { process.exit(1) });

--- a/src/bin/code-suggester.ts
+++ b/src/bin/code-suggester.ts
@@ -16,7 +16,7 @@
 
 import * as yargs from 'yargs';
 import {CREATE_PR_COMMAND, main} from './workflow';
-import { logger } from '../logger';
+import {logger} from '../logger';
 
 // tslint:disable:no-unused-expression
 // yargs actually is a used expression. TS-lint does not detect it.
@@ -104,7 +104,10 @@ yargs
 /**
  * Parse yargs, get change object, invoke framework-core library!
  */
-main().catch((err) => {
+main().catch(err => {
   logger.error(err);
+  /* eslint-disable  no-process-exit */
+  // If just rethrow, the application exists with code 0.
+  // Need exit code 1 to fail GitHub Actions step if the process fails.
   process.exit(1);
 });

--- a/src/bin/code-suggester.ts
+++ b/src/bin/code-suggester.ts
@@ -16,6 +16,7 @@
 
 import * as yargs from 'yargs';
 import {CREATE_PR_COMMAND, main} from './workflow';
+import { logger } from '../logger';
 
 // tslint:disable:no-unused-expression
 // yargs actually is a used expression. TS-lint does not detect it.
@@ -103,4 +104,7 @@ yargs
 /**
  * Parse yargs, get change object, invoke framework-core library!
  */
-main().catch(() => { process.exit(1) });
+main().catch((err) => {
+  logger.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
**Assumptions**: To my knowledge, in order to get a step to fail, the process exit code has to be 1: https://docs.github.com/en/actions/creating-actions/setting-exit-codes-for-actions

**Scenario:**

Currently when the node process fails, it always exits with code 0.

Tested by running local script:
```
if code-suggester pr \
--upstream-repo="dne" \
--upstream-owner="TomKristie" \
--description="describe" \
--title="title" \
--branch="something" \
--primary="master" \
--message="some message" \
--git-dir="./kubernetes"; then
    exit 0
else
    echo "failure exit code non-zero"
    exit 1
fi
```

which tries to fork a non-existent repo.

The output is
```
{"level":30,"time":1597342089072,"pid":8411,"hostname":"penguin","msg":"Starting GitHub PR workflow..."}
{"level":50,"time":1597342089474,"pid":8411,"hostname":"penguin","msg":"Error when forking"}
{"level":50,"time":1597342089474,"pid":8411,"hostname":"penguin","msg":"Workflow failed"}
{"level":50,"time":1597342089474,"pid":8411,"hostname":"penguin","stack":"Error: HttpError: Not Found\n    at Object.fork (/home/kristietom/code-suggester/build/src/github-handler/fork-handler.js:44:15)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)\n    at async Object.createPullRequest (/home/kristietom/code-suggester/build/src/index.js:59:20)\n    at async Object.main (/home/kristietom/code-suggester/build/src/bin/workflow.js:42:17)","type":"Error","msg":"HttpError: Not Found"}
failure exit code non-zero
```
Fixes #72 🦕
