### PR TITLE
fix(patch text to hunk bounds): support regex for patch texts

### DIFF
--- a/src/github-handler/comment-handler/diff-text-handler.ts
+++ b/src/github-handler/comment-handler/diff-text-handler.ts
@@ -1,0 +1,119 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Range} from '../../types';
+
+const INDEX_ORIGINAL = 1;
+const INDEX_UPDATED = 2;
+
+/**
+ * Example output of one output of one regex exec
+ *
+ * '@@ -0,0 +1,12 @@\n', // original text
+ * '0,0', // original hunk
+ * 1,12', // new hunk
+ * index: 0,
+ * input: '@@ -0,0 +1,12 @@\n+Hello world%0A',
+ * groups: undefined
+ *
+ */
+const REGEX_MANY_MANY = /@@ -([0-9]+,[0-9]+) \+([0-9]+,[0-9]+) @@\n/g;
+const REGEX_ONE_MANY = /@@ -([0-9]+) \+([0-9]+,[0-9]+) @@\n/g;
+const REGEX_ONE_ONE = /@@ -([0-9]+) \+([0-9]+) @@\n/g;
+const REGEX_MANY_ONE = /@@ -([0-9]+) \+([0-9]+,[0-9]+) @@\n/g;
+
+/**
+ * Parses the diff-match-patch library char-based patch text
+ * @param {string} patchText
+ * @param {boolean} originalText if set to true returns the original hunk range. If set to false, returns the updated hunk range
+ * @returns patch ranges
+ */
+export function getDiffPatchMatchPatchRange(
+  patchText: string,
+  originalText: boolean
+): Range[] {
+  const index = originalText ? INDEX_ORIGINAL : INDEX_UPDATED;
+  const ranges: Range[] = [];
+  for (
+    let patch = REGEX_MANY_MANY.exec(patchText), i = 0;
+    patch !== null;
+    patch = REGEX_MANY_MANY.exec(patchText), i++
+  ) {
+    const patchData = patch[index].split(',');
+    // the char position of the hunk
+    const start = parseInt(patchData[0]); // start of change
+    const end = parseInt(patchData[1]); // diff-match-patch returns the offset from start char
+    const range = new Range(start, start + end);
+    ranges.push(range);
+  }
+  return ranges;
+}
+
+/**
+ * Parses the GitHub line-based patch text
+ * @param {string} patchText
+ * @returns patch ranges
+ */
+export function getGitHubPatchRanges(patchText: string): Range[] {
+  const ranges: Range[] = [];
+  for (
+    let patch = REGEX_MANY_MANY.exec(patchText);
+    patch !== null;
+    patch = REGEX_MANY_MANY.exec(patchText)
+  ) {
+    // stricly interested in the updated/current github file content
+    const patchData = patch[INDEX_UPDATED].split(',');
+    // the line number ranges of the updated text
+    const start = parseInt(patchData[0]);
+    const end = parseInt(patchData[1]);
+    const range = new Range(start, start + end);
+    ranges.push(range);
+  }
+  for (
+    let patch = REGEX_ONE_MANY.exec(patchText);
+    patch !== null;
+    patch = REGEX_ONE_MANY.exec(patchText)
+  ) {
+    // stricly interested in the updated/current github file content
+    const patchData = patch[INDEX_UPDATED].split(',');
+    // the line number ranges of the updated text
+    const start = parseInt(patchData[0]);
+    const end = parseInt(patchData[1]);
+    const range = new Range(start, start + end);
+    ranges.push(range);
+  }
+  for (
+    let patch = REGEX_ONE_ONE.exec(patchText);
+    patch !== null;
+    patch = REGEX_ONE_ONE.exec(patchText)
+  ) {
+    // stricly interested in the updated/current github file content
+    // the line number ranges of the updated text
+    const start = parseInt(patch[INDEX_UPDATED]);
+    const range = new Range(start, start + 1);
+    ranges.push(range);
+  }
+  for (
+    let patch = REGEX_MANY_ONE.exec(patchText);
+    patch !== null;
+    patch = REGEX_MANY_ONE.exec(patchText)
+  ) {
+    // stricly interested in the updated/current github file content
+    // the line number ranges of the updated text
+    const start = parseInt(patch[INDEX_UPDATED]);
+    const range = new Range(start, start + 1);
+    ranges.push(range);
+  }
+  return ranges;
+}

--- a/src/github-handler/comment-handler/diff-text-handler.ts
+++ b/src/github-handler/comment-handler/diff-text-handler.ts
@@ -53,8 +53,8 @@ export function getDiffPatchMatchPatchRange(
     const patchData = patch[index].split(',');
     // the char position of the hunk
     const start = parseInt(patchData[0]); // start of change
-    const end = parseInt(patchData[1]); // diff-match-patch returns the offset from start char
-    const range = new Range(start, start + end);
+    const offset = parseInt(patchData[1]); // diff-match-patch returns the offset from start char
+    const range = new Range(start, start + offset);
     ranges.push(range);
   }
   return ranges;
@@ -76,8 +76,8 @@ export function getGitHubPatchRanges(patchText: string): Range[] {
     const patchData = patch[INDEX_UPDATED].split(',');
     // the line number ranges of the updated text
     const start = parseInt(patchData[0]);
-    const end = parseInt(patchData[1]);
-    const range = new Range(start, start + end);
+    const offset = parseInt(patchData[1]);
+    const range = new Range(start, start + offset);
     ranges.push(range);
   }
   for (
@@ -89,8 +89,8 @@ export function getGitHubPatchRanges(patchText: string): Range[] {
     const patchData = patch[INDEX_UPDATED].split(',');
     // the line number ranges of the updated text
     const start = parseInt(patchData[0]);
-    const end = parseInt(patchData[1]);
-    const range = new Range(start, start + end);
+    const offset = parseInt(patchData[1]);
+    const range = new Range(start, start + offset);
     ranges.push(range);
   }
   for (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,3 +116,36 @@ export interface CreatePullRequest {
   // Whether or not maintainers can modify the PR.
   maintainersCanModify: boolean;
 }
+
+export class RawContent {
+  public readonly old_content: string;
+  public readonly new_content: string;
+  constructor(old_content: string, new_content: string) {
+    this.old_content = old_content;
+    this.new_content = new_content;
+  }
+}
+export class Range {
+  public start: number;
+  public end: number;
+  constructor(start: number, end: number) {
+    this.start = start;
+    this.end = end;
+  }
+}
+
+export class Patch {
+  public start: number;
+  public end: number;
+  public content: string;
+  constructor(start: number, end: number, content: string) {
+    this.start = start;
+    this.end = end;
+    this.content = content;
+  }
+}
+
+export type FilePatches = Map<string, Patch[]>;
+export type RawChanges = Map<string, RawContent>;
+export type PatchText = Map<string, string>;
+export type FileRanges = Map<string, Range[]>;

--- a/test/regex-patch.ts
+++ b/test/regex-patch.ts
@@ -14,7 +14,10 @@
 
 import {expect} from 'chai';
 import {describe, it} from 'mocha';
-import {getDiffPatchMatchPatchRange, getGitHubPatchRanges} from '../src/github-handler/comment-handler/diff-text-handler';
+import {
+  getDiffPatchMatchPatchRange,
+  getGitHubPatchRanges,
+} from '../src/github-handler/comment-handler/diff-text-handler';
 
 describe('Getting patch range from patch text', async () => {
   describe('diff-match-patch patch text', () => {
@@ -83,8 +86,7 @@ describe('Getting patch range from patch text', async () => {
   });
 
   describe('GitHub patch text', () => {
-    const gitHubListFilesData = 
-    [
+    const gitHubListFilesData = [
       {
         sha: 'a1d470fa4d7b04450715e3e02d240a34517cd988',
         filename: 'Readme.md',
@@ -92,10 +94,14 @@ describe('Getting patch range from patch text', async () => {
         additions: 4,
         deletions: 1,
         changes: 5,
-        blob_url: 'https://github.com/TomKristie/HelloWorld/blob/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
-        raw_url: 'https://github.com/TomKristie/HelloWorld/raw/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
-        contents_url: 'https://api.github.com/repos/TomKristie/HelloWorld/contents/Readme.md?ref=eb53f3871f56e8dd6321e44621fe6ac2da1bc120',
-        patch: "@@ -1,2 +1,5 @@\n Hello world\n-!\n+Goodbye World\n+gOodBYE world\n+\n+Goodbye World"
+        blob_url:
+          'https://github.com/TomKristie/HelloWorld/blob/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+        raw_url:
+          'https://github.com/TomKristie/HelloWorld/raw/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+        contents_url:
+          'https://api.github.com/repos/TomKristie/HelloWorld/contents/Readme.md?ref=eb53f3871f56e8dd6321e44621fe6ac2da1bc120',
+        patch:
+          '@@ -1,2 +1,5 @@\n Hello world\n-!\n+Goodbye World\n+gOodBYE world\n+\n+Goodbye World',
       },
       {
         sha: '8b137891791fe96927ad78e64b0aad7bded08bdc',
@@ -104,10 +110,13 @@ describe('Getting patch range from patch text', async () => {
         additions: 1,
         deletions: 1,
         changes: 2,
-        blob_url: 'https://github.com/TomKristie/HelloWorld/blob/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/foo/foo.txt',
-        raw_url: 'https://github.com/TomKristie/HelloWorld/raw/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/foo/foo.txt',
-        contents_url: 'https://api.github.com/repos/TomKristie/HelloWorld/contents/foo/foo.txt?ref=eb53f3871f56e8dd6321e44621fe6ac2da1bc120',
-        patch: "@@ -1 +1 @@\n-Hello foo\n+"
+        blob_url:
+          'https://github.com/TomKristie/HelloWorld/blob/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/foo/foo.txt',
+        raw_url:
+          'https://github.com/TomKristie/HelloWorld/raw/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/foo/foo.txt',
+        contents_url:
+          'https://api.github.com/repos/TomKristie/HelloWorld/contents/foo/foo.txt?ref=eb53f3871f56e8dd6321e44621fe6ac2da1bc120',
+        patch: '@@ -1 +1 @@\n-Hello foo\n+',
       },
       {
         sha: '3b18e512dba79e4c8300dd08aeb37f8e728b8dad',
@@ -116,29 +125,32 @@ describe('Getting patch range from patch text', async () => {
         additions: 0,
         deletions: 1,
         changes: 1,
-        blob_url: 'https://github.com/TomKristie/HelloWorld/blob/f5da827a725a701302da7db2da16b1678f52fdcc/helloworld.txt',
-        raw_url: 'https://github.com/TomKristie/HelloWorld/raw/f5da827a725a701302da7db2da16b1678f52fdcc/helloworld.txt',
-        contents_url: 'https://api.github.com/repos/TomKristie/HelloWorld/contents/helloworld.txt?ref=f5da827a725a701302da7db2da16b1678f52fdcc',
-        patch: "@@ -1 +0,0 @@\n-hello world"
-      }
-    ]
-      it('parses original text for multiline modifies', () => {
-          const patch = gitHubListFilesData[0];
-          const ranges = getGitHubPatchRanges(patch.patch);
-          expect(ranges[0].start).equals(1);
-          expect(ranges[0].end).equals(6);
-      });
-      it('parses original text for single line modifies at the start of the file', () => {
-          const patch = gitHubListFilesData[1];
-          const ranges = getGitHubPatchRanges(patch.patch);
-          expect(ranges[0].start).equals(1);
-          expect(ranges[0].end).equals(2);
-      });
-      it('parses original text for single line deletes', () => {
-          const patch = gitHubListFilesData[2];
-          const ranges = getGitHubPatchRanges(patch.patch);
-          expect(ranges[0].start).equals(0);
-          expect(ranges[0].end).equals(0);
-      });
+        blob_url:
+          'https://github.com/TomKristie/HelloWorld/blob/f5da827a725a701302da7db2da16b1678f52fdcc/helloworld.txt',
+        raw_url:
+          'https://github.com/TomKristie/HelloWorld/raw/f5da827a725a701302da7db2da16b1678f52fdcc/helloworld.txt',
+        contents_url:
+          'https://api.github.com/repos/TomKristie/HelloWorld/contents/helloworld.txt?ref=f5da827a725a701302da7db2da16b1678f52fdcc',
+        patch: '@@ -1 +0,0 @@\n-hello world',
+      },
+    ];
+    it('parses original text for multiline modifies', () => {
+      const patch = gitHubListFilesData[0];
+      const ranges = getGitHubPatchRanges(patch.patch);
+      expect(ranges[0].start).equals(1);
+      expect(ranges[0].end).equals(6);
+    });
+    it('parses original text for single line modifies at the start of the file', () => {
+      const patch = gitHubListFilesData[1];
+      const ranges = getGitHubPatchRanges(patch.patch);
+      expect(ranges[0].start).equals(1);
+      expect(ranges[0].end).equals(2);
+    });
+    it('parses original text for single line deletes', () => {
+      const patch = gitHubListFilesData[2];
+      const ranges = getGitHubPatchRanges(patch.patch);
+      expect(ranges[0].start).equals(0);
+      expect(ranges[0].end).equals(0);
+    });
   });
 });

--- a/test/regex-patch.ts
+++ b/test/regex-patch.ts
@@ -1,0 +1,144 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {expect} from 'chai';
+import {describe, it} from 'mocha';
+import {getDiffPatchMatchPatchRange, getGitHubPatchRanges} from '../src/github-handler/comment-handler/diff-text-handler';
+
+describe('Getting patch range from patch text', async () => {
+  describe('diff-match-patch patch text', () => {
+    it('gets the original ranges of the patch when the file has text strictly additions from empty file', () => {
+      const patch = '@@ -0,0 +1,12 @@\n+Hello world%0A';
+      const latestRanges = getDiffPatchMatchPatchRange(patch, true);
+      expect(latestRanges[0].start).equals(0);
+      expect(latestRanges[0].end).equals(0);
+    });
+    it('gets the original ranges of the patch when the file has text deletions', () => {
+      const patch = '@@ -1,7 +0,0 @@\n-deleted';
+      const latestRanges = getDiffPatchMatchPatchRange(patch, true);
+      expect(latestRanges[0].start).equals(1);
+      expect(latestRanges[0].end).equals(8);
+    });
+    it('gets the original ranges of the patch when the file has text substitution', () => {
+      const patch = '@@ -1,7 +1,16 @@\n-changed\n+to something new';
+      const latestRanges = getDiffPatchMatchPatchRange(patch, true);
+      expect(latestRanges[0].start).equals(1);
+      expect(latestRanges[0].end).equals(8);
+    });
+    it('gets the original ranges of the patch where the edit is strictly appending', () => {
+      const patch = '@@ -1,6 +1,28 @@\n append\n+%0Ameans add comes after';
+      const latestRanges = getDiffPatchMatchPatchRange(patch, true);
+      expect(latestRanges[0].start).equals(1);
+      expect(latestRanges[0].end).equals(7);
+    });
+    it('gets the original ranges of a file that has multiple deletes and edits', () => {
+      const patch =
+        '@@ -13,9 +13,10 @@\n Good\n-b\n+ B\n ye W\n@@ -29,7 +29,4 @@\n ame%0A\n-end';
+      const latestRanges = getDiffPatchMatchPatchRange(patch, true);
+      expect(latestRanges[0].start).equals(13);
+      expect(latestRanges[0].end).equals(22);
+    });
+    it('gets the updated ranges of the patch when the file has text strictly additions from empty file', () => {
+      const patch = '@@ -0,0 +1,12 @@\n+Hello world%0A';
+      const latestRanges = getDiffPatchMatchPatchRange(patch, false);
+      expect(latestRanges[0].start).equals(1);
+      expect(latestRanges[0].end).equals(13);
+    });
+    it('gets the updated ranges of the patch when the file has text deletions', () => {
+      const patch = '@@ -1,7 +0,0 @@\n-deleted';
+      const latestRanges = getDiffPatchMatchPatchRange(patch, false);
+      expect(latestRanges[0].start).equals(0);
+      expect(latestRanges[0].end).equals(0);
+    });
+    it('gets the updated ranges of the patch when the file has text substitution', () => {
+      const patch = '@@ -1,7 +1,16 @@\n-changed\n+to something new';
+      const latestRanges = getDiffPatchMatchPatchRange(patch, false);
+      expect(latestRanges[0].start).equals(1);
+      expect(latestRanges[0].end).equals(17);
+    });
+    it('gets the updated ranges of the patch where the edit is strictly appending', () => {
+      const patch = '@@ -1,6 +1,28 @@\n append\n+%0Ameans add comes after';
+      const latestRanges = getDiffPatchMatchPatchRange(patch, false);
+      expect(latestRanges[0].start).equals(1);
+      expect(latestRanges[0].end).equals(29);
+    });
+    it('gets the original ranges of a file that has multiple deletes and edits', () => {
+      const patch =
+        '@@ -13,9 +13,10 @@\n Good\n-b\n+ B\n ye W\n@@ -29,7 +29,4 @@\n ame%0A\n-end';
+      const latestRanges = getDiffPatchMatchPatchRange(patch, false);
+      expect(latestRanges[0].start).equals(13);
+      expect(latestRanges[0].end).equals(23);
+    });
+  });
+
+  describe('GitHub patch text', () => {
+    const gitHubListFilesData = 
+    [
+      {
+        sha: 'a1d470fa4d7b04450715e3e02d240a34517cd988',
+        filename: 'Readme.md',
+        status: 'modified',
+        additions: 4,
+        deletions: 1,
+        changes: 5,
+        blob_url: 'https://github.com/TomKristie/HelloWorld/blob/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+        raw_url: 'https://github.com/TomKristie/HelloWorld/raw/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+        contents_url: 'https://api.github.com/repos/TomKristie/HelloWorld/contents/Readme.md?ref=eb53f3871f56e8dd6321e44621fe6ac2da1bc120',
+        patch: "@@ -1,2 +1,5 @@\n Hello world\n-!\n+Goodbye World\n+gOodBYE world\n+\n+Goodbye World"
+      },
+      {
+        sha: '8b137891791fe96927ad78e64b0aad7bded08bdc',
+        filename: 'foo/foo.txt',
+        status: 'modified',
+        additions: 1,
+        deletions: 1,
+        changes: 2,
+        blob_url: 'https://github.com/TomKristie/HelloWorld/blob/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/foo/foo.txt',
+        raw_url: 'https://github.com/TomKristie/HelloWorld/raw/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/foo/foo.txt',
+        contents_url: 'https://api.github.com/repos/TomKristie/HelloWorld/contents/foo/foo.txt?ref=eb53f3871f56e8dd6321e44621fe6ac2da1bc120',
+        patch: "@@ -1 +1 @@\n-Hello foo\n+"
+      },
+      {
+        sha: '3b18e512dba79e4c8300dd08aeb37f8e728b8dad',
+        filename: 'helloworld.txt',
+        status: 'removed',
+        additions: 0,
+        deletions: 1,
+        changes: 1,
+        blob_url: 'https://github.com/TomKristie/HelloWorld/blob/f5da827a725a701302da7db2da16b1678f52fdcc/helloworld.txt',
+        raw_url: 'https://github.com/TomKristie/HelloWorld/raw/f5da827a725a701302da7db2da16b1678f52fdcc/helloworld.txt',
+        contents_url: 'https://api.github.com/repos/TomKristie/HelloWorld/contents/helloworld.txt?ref=f5da827a725a701302da7db2da16b1678f52fdcc',
+        patch: "@@ -1 +0,0 @@\n-hello world"
+      }
+    ]
+      it('parses original text for multiline modifies', () => {
+          const patch = gitHubListFilesData[0];
+          const ranges = getGitHubPatchRanges(patch.patch);
+          expect(ranges[0].start).equals(1);
+          expect(ranges[0].end).equals(6);
+      });
+      it('parses original text for single line modifies at the start of the file', () => {
+          const patch = gitHubListFilesData[1];
+          const ranges = getGitHubPatchRanges(patch.patch);
+          expect(ranges[0].start).equals(1);
+          expect(ranges[0].end).equals(2);
+      });
+      it('parses original text for single line deletes', () => {
+          const patch = gitHubListFilesData[2];
+          const ranges = getGitHubPatchRanges(patch.patch);
+          expect(ranges[0].start).equals(0);
+          expect(ranges[0].end).equals(0);
+      });
+  });
+});


### PR DESCRIPTION
Get the patch range (start, end) from patch text which gives (start, offset). This range is needed so that from a raw old file and raw new file, we can calculate what lines to suggest edits, and what text file content belong in the lines to suggest.

Given patch text from:

[GitHub](https://developer.github.com/v3/pulls/#list-pull-requests-files) which gives output i.e. `@@ -132,7 +132,7 @@ module Test @@ -1000,7 +1000,7 @@ module Test`


and [diff-match-patch library](https://github.com/google/diff-match-patch) where you can first compute the patch object i.e.
```js
{
  diffs: [ [ -1, 'foo\nbar' ], [ 1, 'bar\nfoo' ], [ 0, '\nfoo' ] ],
  start1: 0,
  start2: 0,
  length1: 11,
  length2: 11
}
```
and then convert the patch object to patch text i.e. `@@ -1,11 +1,11 @@\n-foo%0Abar\n+bar%0Afoo\n %0Afoo`

map the patch text to a list of patch ranges by use of regex.

Towards #59  🦕
