### PR TITLE
fix(framework-core): core-library get remote patch ranges

### DIFF
--- a/src/github-handler/comment-handler/github-patch-format-handler.ts
+++ b/src/github-handler/comment-handler/github-patch-format-handler.ts
@@ -40,8 +40,9 @@ const REGEX_ONELINE_RANGE = /@@ -([0-9]+) \+([0-9]+) @@/g;
 const REGEX_MULTILINE_TO_ONELINE_RANGE = /@@ -([0-9]+,[0-9]+) \+([0-9]+) @@/g;
 
 /**
- * Parses the GitHub line-based patch text
- * Example output of one output of one regex exec
+ * Parses the GitHub line-based patch text.
+ * Throws an error if the patch text is undefined, null, or not a patch text.
+ * Example output of one output of one regex exec:
  *
  * '@@ -0,0 +1,12 @@\n', // original text
  * '0,0', // original hunk

--- a/src/github-handler/comment-handler/github-patch-format-handler.ts
+++ b/src/github-handler/comment-handler/github-patch-format-handler.ts
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Range} from '../../types';
+import {PatchSyntaxError, Range} from '../../types';
+import {logger} from '../../logger';
 
 const REGEX_INDEX_OF_UPDATED_HUNK = 2;
 
@@ -52,6 +53,9 @@ const REGEX_MULTILINE_TO_ONELINE_RANGE = /@@ -([0-9]+,[0-9]+) \+([0-9]+) @@/g;
  * @returns patch ranges
  */
 export function getGitHubPatchRanges(patchText: string): Range[] {
+  if (typeof patchText !== 'string') {
+    throw new TypeError('GitHub patch text must be a string');
+  }
   const ranges: Range[] = [];
   // CASE I: multiline patch ranges
   // includes non-first single-line patches
@@ -108,6 +112,12 @@ export function getGitHubPatchRanges(patchText: string): Range[] {
     const start = parseInt(patch[REGEX_INDEX_OF_UPDATED_HUNK]);
     const range: Range = {start, end: start + 1};
     ranges.push(range);
+  }
+  if (!ranges.length) {
+    logger.error(
+    `Unexpected input patch text provided. Expected "${patchText}" to be of format @@ -<number>[,<number>] +<number>[,<number>] @@`
+  );
+  throw new PatchSyntaxError('Unexpected patch text format');
   }
   return ranges;
 }

--- a/src/github-handler/comment-handler/github-patch-format-handler.ts
+++ b/src/github-handler/comment-handler/github-patch-format-handler.ts
@@ -115,9 +115,9 @@ export function getGitHubPatchRanges(patchText: string): Range[] {
   }
   if (!ranges.length) {
     logger.error(
-    `Unexpected input patch text provided. Expected "${patchText}" to be of format @@ -<number>[,<number>] +<number>[,<number>] @@`
-  );
-  throw new PatchSyntaxError('Unexpected patch text format');
+      `Unexpected input patch text provided. Expected "${patchText}" to be of format @@ -<number>[,<number>] +<number>[,<number>] @@`
+    );
+    throw new PatchSyntaxError('Unexpected patch text format');
   }
   return ranges;
 }

--- a/src/github-handler/comment-handler/remote-patch-ranges-handler.ts
+++ b/src/github-handler/comment-handler/remote-patch-ranges-handler.ts
@@ -13,12 +13,7 @@
 // limitations under the License.
 
 import {Octokit} from '@octokit/rest';
-import {
-  FileRanges,
-  PatchText,
-  Range,
-  RepoDomain,
-} from '../../types';
+import {FileRanges, PatchText, Range, RepoDomain} from '../../types';
 import {getGitHubPatchRanges} from './github-patch-format-handler';
 import {logger} from '../../logger';
 

--- a/src/github-handler/comment-handler/remote-patch-ranges-handler.ts
+++ b/src/github-handler/comment-handler/remote-patch-ranges-handler.ts
@@ -1,0 +1,122 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Octokit} from '@octokit/rest';
+import {FileRanges, PatchText, Range, RepoDomain} from '../../types';
+import {getGitHubPatchRanges} from './github-patch-format-handler';
+import {logger} from '../../logger';
+
+/**
+ * Get each pull request remote file's patch text asynchronously
+ * @param {Octokit} octokit the authenticated octokit instance
+ * @param {RepoDomain} remote the remote repository domain information
+ * @param {number} pullNumber the pull request number
+ * @param {number} pageSize the number of results to return per page
+ * @returns {Promise<Promise<Object<PatchText, string[]>>>} the stringified patch data for each file and the list of files whose patch data could not be resolved
+ */
+export async function getCurrentPulLRequestPatches(
+  octokit: Octokit,
+  remote: RepoDomain,
+  pullNumber: number,
+  pageSize: number
+): Promise<{patches: PatchText; filesMissingPatch: string[]}> {
+  // TODO support pagination
+  const filesMissingPatch: string[] = [];
+  const files = (
+    await octokit.pulls.listFiles({
+      owner: remote.owner,
+      repo: remote.repo,
+      pull_number: pullNumber,
+      per_page: pageSize,
+    })
+  ).data;
+  const patches: PatchText = new Map<string, string>();
+  if (files.length === 0) {
+    logger.error(
+      `0 file results have returned from list files query for Pull Request #${pullNumber}. Cannot make suggestions on an empty Pull Request`
+    );
+    throw Error('Empty Pull Request');
+  }
+  files.forEach(file => {
+    if (file.patch === undefined) {
+      // files that are too large do not return the patch text by default
+      // TODO handle files that are too large
+      logger.warn(
+        `File ${file.filename} is too large to display patch object.`
+      );
+      filesMissingPatch.push(file.filename);
+    } else {
+      patches.set(file.filename, file.patch);
+    }
+  });
+  if (patches.size === 0) {
+    logger.warn(
+      '0 patches have been returned. This could be because the patch results were too large to return.'
+    );
+  }
+  return {patches, filesMissingPatch};
+}
+
+/**
+ * Given the patch text (for a whole file) for each file,
+ * get each file's hunk's (part of a file's) range
+ * @param {PatchText} validPatches patch text from the remote github file
+ * @returns {FileRanges} the range of the remote patch
+ */
+export function patchTextToRanges(validPatches: PatchText): FileRanges {
+  const allValidLineRanges: FileRanges = new Map<string, Range[]>();
+  validPatches.forEach((patch, filename) => {
+    // get each hunk range in the patch string
+    const validLineRanges = getGitHubPatchRanges(patch);
+    if (!validLineRanges.length) {
+      logger.error(
+        `Unexpected input patch text provided. Expected "${patch}" to be of format @@ -<number>[,<number>] +<number>[,<number>] @@`
+      );
+      throw Error('Unexpected patch text format');
+    }
+    allValidLineRanges.set(filename, validLineRanges);
+  });
+  return allValidLineRanges;
+}
+
+/**
+ * Get each pull request remote file's current patch range to identify the scope of each patch
+ * @param {Octokit} octokit the authenticated octokit instance
+ * @param {RepoDomain} remote the remote repository domain information
+ * @param {number} pullNumber the pull request number
+ * @param {number} pageSize the number of files to return per pull request list files query
+ * @returns {Promise<Object<FileRanges, string[]>>} the scope of each file in the pull request and the list of files whose patch data could not be resolved
+ */
+export async function getAllValidFileRanges(
+  octokit: Octokit,
+  remote: RepoDomain,
+  pullNumber: number,
+  pageSize: number
+): Promise<{validFileLines: FileRanges; filesMissingPatch: string[]}> {
+  try {
+    const {patches, filesMissingPatch} = await getCurrentPulLRequestPatches(
+      octokit,
+      remote,
+      pullNumber,
+      pageSize
+    );
+    const validFileLines = patchTextToRanges(patches);
+    return {validFileLines, filesMissingPatch};
+  } catch (err) {
+    logger.error(
+      'Could not convert the remote pull request file patch text to ranges'
+    );
+    throw err;
+  }
+}

--- a/src/github-handler/comment-handler/remote-patch-ranges-handler.ts
+++ b/src/github-handler/comment-handler/remote-patch-ranges-handler.ts
@@ -103,7 +103,7 @@ export async function getAllValidFileRanges(
   remote: RepoDomain,
   pullNumber: number,
   pageSize: number
-): Promise<{validFileLines: FileRanges; filesMissingPatch: string[]}> {
+): Promise<{validFileLines: FileRanges; invalidFiles: string[]}> {
   try {
     const {patches, filesMissingPatch} = await getCurrentPulLRequestPatches(
       octokit,
@@ -112,7 +112,7 @@ export async function getAllValidFileRanges(
       pageSize
     );
     const validFileLines = patchTextToRanges(patches);
-    return {validFileLines, filesMissingPatch};
+    return {validFileLines, invalidFiles: filesMissingPatch};
   } catch (err) {
     logger.error(
       'Could not convert the remote pull request file patch text to ranges'

--- a/src/github-handler/comment-handler/remote-patch-ranges-handler.ts
+++ b/src/github-handler/comment-handler/remote-patch-ranges-handler.ts
@@ -18,12 +18,13 @@ import {getGitHubPatchRanges} from './github-patch-format-handler';
 import {logger} from '../../logger';
 
 /**
- * Get each pull request remote file's patch text asynchronously
+ * For a pull request, get each remote file's patch text asynchronously
+ * Also get the list of files whose patch data could not be returned
  * @param {Octokit} octokit the authenticated octokit instance
  * @param {RepoDomain} remote the remote repository domain information
  * @param {number} pullNumber the pull request number
  * @param {number} pageSize the number of results to return per page
- * @returns {Promise<Promise<Object<PatchText, string[]>>>} the stringified patch data for each file and the list of files whose patch data could not be resolved
+ * @returns {Promise<Object<PatchText, string[]>>} the stringified patch data for each file and the list of files whose patch data could not be resolved
  */
 export async function getCurrentPulLRequestPatches(
   octokit: Octokit,
@@ -91,14 +92,16 @@ export function patchTextToRanges(validPatches: PatchText): FileRanges {
 }
 
 /**
- * Get each pull request remote file's current patch range to identify the scope of each patch
+ * For a pull request, get each remote file's current patch range to identify the scope of each patch as a Map,
+ * as well as a list of files that cannot have suggestions applied to it within the Pull Request.
+ * The list of files are a subset of the total out-of-scope files.
  * @param {Octokit} octokit the authenticated octokit instance
  * @param {RepoDomain} remote the remote repository domain information
  * @param {number} pullNumber the pull request number
  * @param {number} pageSize the number of files to return per pull request list files query
  * @returns {Promise<Object<FileRanges, string[]>>} the scope of each file in the pull request and the list of files whose patch data could not be resolved
  */
-export async function getAllValidFileRanges(
+export async function getPullRequestScope(
   octokit: Octokit,
   remote: RepoDomain,
   pullNumber: number,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,6 +117,13 @@ export interface CreatePullRequest {
   maintainersCanModify: boolean;
 }
 
+export class PatchSyntaxError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PatchSyntaxError';
+  }
+}
+
 /**
  * The file content of the original content and the patched content
  */

--- a/test/github-regex-patch.ts
+++ b/test/github-regex-patch.ts
@@ -19,38 +19,38 @@ import {PatchSyntaxError} from '../src/types';
 
 describe('Getting patch range from GitHub patch text', async () => {
   it('parses original text for multiline modifies', () => {
-    const multiline_patch =
+    const multilinePatch =
       '@@ -1,2 +1,5 @@\n Hello world\n-!\n+Goodbye World\n+gOodBYE world\n+\n+Goodbye World';
-    const ranges = getGitHubPatchRanges(multiline_patch);
+    const ranges = getGitHubPatchRanges(multilinePatch);
     expect(ranges[0].start).equals(1);
     expect(ranges[0].end).equals(6);
     expect(ranges.length).equals(1);
   });
   it('parses original text for single line modifies at the start of the file', () => {
-    const first_line_patch = '@@ -1 +1 @@\n-Hello foo\n+';
-    const ranges = getGitHubPatchRanges(first_line_patch);
+    const firstLinePatch = '@@ -1 +1 @@\n-Hello foo\n+';
+    const ranges = getGitHubPatchRanges(firstLinePatch);
     expect(ranges[0].start).equals(1);
     expect(ranges[0].end).equals(2);
     expect(ranges.length).equals(1);
   });
   it('parses original text for single line deletes', () => {
-    const single_line_to_multiline_format = '@@ -1 +0,0 @@\n-hello world';
-    const ranges = getGitHubPatchRanges(single_line_to_multiline_format);
+    const singleLineToMultilineFormat = '@@ -1 +0,0 @@\n-hello world';
+    const ranges = getGitHubPatchRanges(singleLineToMultilineFormat);
     expect(ranges[0].start).equals(0);
     expect(ranges[0].end).equals(0);
     expect(ranges.length).equals(1);
   });
   it('parses original text for single line file creations', () => {
-    const first_line_patch = "@@ -0,0 +1 @@\n+console.log('Hello World!');";
-    const ranges = getGitHubPatchRanges(first_line_patch);
+    const firstLinePatch = "@@ -0,0 +1 @@\n+console.log('Hello World!');";
+    const ranges = getGitHubPatchRanges(firstLinePatch);
     expect(ranges[0].start).equals(1);
     expect(ranges[0].end).equals(2);
     expect(ranges.length).equals(1);
   });
   it('parses patch text with multiple patches', () => {
-    const first_line_patch =
+    const multiplePatch =
       '@@ -356,6 +356,7 @@ Hello\n Hello\n Hello\n Hello\n+Bye\n Hello\n Hello\n Hello\n@@ -6576,8 +6577,7 @@ Hello\n Hello\n Hello\n Hello\n-Hello\n-Hello\n+Bye\n Hello\n Hello\n Hello';
-    const ranges = getGitHubPatchRanges(first_line_patch);
+    const ranges = getGitHubPatchRanges(multiplePatch);
     expect(ranges[0].start).equals(356);
     expect(ranges[0].end).equals(363);
     expect(ranges[1].start).equals(6577);

--- a/test/github-regex-patch.ts
+++ b/test/github-regex-patch.ts
@@ -15,6 +15,7 @@
 import {expect} from 'chai';
 import {describe, it} from 'mocha';
 import {getGitHubPatchRanges} from '../src/github-handler/comment-handler/github-patch-format-handler';
+import { PatchSyntaxError } from '../src/types';
 
 describe('Getting patch range from GitHub patch text', async () => {
   it('parses original text for multiline modifies', () => {
@@ -55,5 +56,41 @@ describe('Getting patch range from GitHub patch text', async () => {
     expect(ranges[1].start).equals(6577);
     expect(ranges[1].end).equals(6584);
     expect(ranges.length).equals(2);
+  });
+  it('throws an error when the patch text is null', () => {
+    const patch = (null as unknown) as string;
+    try {
+      getGitHubPatchRanges(patch);
+      expect.fail('Should have filed because an invalid input was given');
+    } catch (err) {
+      expect(err instanceof TypeError).equals(true);
+    }
+  });
+  it('throws an error when the patch text is undefined', () => {
+    const patch = (undefined as unknown) as string;
+    try {
+      getGitHubPatchRanges(patch);
+      expect.fail('Should have filed because an invalid input was given');
+    } catch (err) {
+      expect(err instanceof TypeError).equals(true);
+    }
+  });
+  it('throws an error when the patch text does not contain hunk ranges and contains other text', () => {
+    const patch = '@ 1 1 @ invalid patch because it needs a + and - sign'
+    try {
+      getGitHubPatchRanges(patch);
+      expect.fail('Should have filed because an invalid input was given');
+    } catch (err) {
+      expect(err instanceof PatchSyntaxError).equals(true);
+    }
+  });
+  it('throws an error when the patch text does not contain hunk ranges because it is an empty string', () => {
+    const patch = '';
+    try {
+      getGitHubPatchRanges(patch);
+      expect.fail('Should have filed because an invalid input was given');
+    } catch (err) {
+      expect(err instanceof PatchSyntaxError).equals(true);
+    }
   });
 });

--- a/test/github-regex-patch.ts
+++ b/test/github-regex-patch.ts
@@ -15,7 +15,7 @@
 import {expect} from 'chai';
 import {describe, it} from 'mocha';
 import {getGitHubPatchRanges} from '../src/github-handler/comment-handler/github-patch-format-handler';
-import { PatchSyntaxError } from '../src/types';
+import {PatchSyntaxError} from '../src/types';
 
 describe('Getting patch range from GitHub patch text', async () => {
   it('parses original text for multiline modifies', () => {
@@ -76,7 +76,7 @@ describe('Getting patch range from GitHub patch text', async () => {
     }
   });
   it('throws an error when the patch text does not contain hunk ranges and contains other text', () => {
-    const patch = '@ 1 1 @ invalid patch because it needs a + and - sign'
+    const patch = '@ 1 1 @ invalid patch because it needs a + and - sign';
     try {
       getGitHubPatchRanges(patch);
       expect.fail('Should have filed because an invalid input was given');

--- a/test/remote-github-patch-text.ts
+++ b/test/remote-github-patch-text.ts
@@ -418,7 +418,7 @@ describe('Getting the pull request files updated patch lines', () => {
       .resolves(listFilesOfPRResult);
 
     // tests
-    const {validFileLines, filesMissingPatch} = await getAllValidFileRanges(
+    const {validFileLines, invalidFiles: filesMissingPatch} = await getAllValidFileRanges(
       octokit,
       upstream,
       pullNumber,

--- a/test/remote-github-patch-text.ts
+++ b/test/remote-github-patch-text.ts
@@ -19,7 +19,7 @@ import * as sinon from 'sinon';
 import {
   patchTextToRanges,
   getCurrentPulLRequestPatches,
-  getAllValidFileRanges,
+  getPullRequestScope,
 } from '../src/github-handler/comment-handler/remote-patch-ranges-handler';
 import {Range} from '../src/types';
 import {Octokit} from '@octokit/rest';
@@ -418,12 +418,10 @@ describe('Getting the pull request files updated patch lines', () => {
       .resolves(listFilesOfPRResult);
 
     // tests
-    const {validFileLines, invalidFiles: filesMissingPatch} = await getAllValidFileRanges(
-      octokit,
-      upstream,
-      pullNumber,
-      pageSize
-    );
+    const {
+      validFileLines,
+      invalidFiles: filesMissingPatch,
+    } = await getPullRequestScope(octokit, upstream, pullNumber, pageSize);
     sandbox.assert.calledOnceWithExactly(stub, {
       owner: upstream.owner,
       repo: upstream.repo,
@@ -445,9 +443,9 @@ describe('Getting the pull request files updated patch lines', () => {
 
     // tests
     try {
-      await getAllValidFileRanges(octokit, upstream, pullNumber, pageSize);
+      await getPullRequestScope(octokit, upstream, pullNumber, pageSize);
       expect.fail(
-        'The getAllValidFileRanges function should have failed because Octokit failed.'
+        'The getPullRequestScope function should have failed because Octokit failed.'
       );
     } catch (err) {
       expect(err.message).equals(errorMsg);

--- a/test/remote-github-patch-text.ts
+++ b/test/remote-github-patch-text.ts
@@ -295,15 +295,15 @@ describe('patchTextToRanges', () => {
   });
   it('Returns a single range file record when there is a single 1 line patch hunk', () => {
     const firstLinePatch = '@@ -1 +1 @@\n-Hello foo\n+';
-    const singlelineFIleName = 'single-line-patch.txt';
+    const singleLineFileName = 'single-line-patch.txt';
     const patchText = new Map<string, string>();
-    patchText.set(singlelineFIleName, firstLinePatch);
+    patchText.set(singleLineFileName, firstLinePatch);
     const ranges = patchTextToRanges(patchText);
     expect(ranges.size).equals(1);
-    expect(ranges.get(singlelineFIleName)).not.equals(null);
-    expect(ranges.get(singlelineFIleName)?.length).equals(1);
-    expect(ranges.get(singlelineFIleName)![0].start).equals(1);
-    expect(ranges.get(singlelineFIleName)![0].end).equals(2);
+    expect(ranges.get(singleLineFileName)).not.equals(null);
+    expect(ranges.get(singleLineFileName)?.length).equals(1);
+    expect(ranges.get(singleLineFileName)![0].start).equals(1);
+    expect(ranges.get(singleLineFileName)![0].end).equals(2);
   });
   it('Returns a single range file record when there is a single 1 line to multiline line patch hunk', () => {
     const singleToMultilineFormat = '@@ -1 +0,0 @@\n-hello world';

--- a/test/remote-github-patch-text.ts
+++ b/test/remote-github-patch-text.ts
@@ -1,0 +1,456 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {expect} from 'chai';
+import {describe, it, before, afterEach} from 'mocha';
+import {setup} from './util';
+import * as sinon from 'sinon';
+import {
+  patchTextToRanges,
+  getCurrentPulLRequestPatches,
+  getAllValidFileRanges,
+} from '../src/github-handler/comment-handler/remote-patch-ranges-handler';
+import {Range} from '../src/types';
+import {Octokit} from '@octokit/rest';
+import {logger} from '../src/logger';
+
+before(() => {
+  setup();
+});
+
+describe('Listing pull request files', () => {
+  const sandbox = sinon.createSandbox();
+  afterEach(() => {
+    sandbox.restore();
+  });
+  const upstream = {owner: 'upstream-owner', repo: 'upstream-repo'};
+  const pullNumber = 10;
+  const pageSize = 80;
+  const octokit = new Octokit({});
+
+  it('Calls Octokit with the correct values', async () => {
+    // setup
+    const listFilesOfPRResult = {
+      headers: {},
+      status: 200,
+      url: 'http://fake-url.com',
+      data: [
+        {
+          sha: 'a1d470fa4d7b04450715e3e02d240a34517cd988',
+          filename: 'Readme.md',
+          status: 'modified',
+          additions: 4,
+          deletions: 1,
+          changes: 5,
+          blob_url:
+            'https://github.com/TomKristie/HelloWorld/blob/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+          raw_url:
+            'https://github.com/TomKristie/HelloWorld/raw/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+          contents_url:
+            'https://api.github.com/repos/TomKristie/HelloWorld/contents/Readme.md?ref=eb53f3871f56e8dd6321e44621fe6ac2da1bc120',
+          patch:
+            '@@ -1,2 +1,5 @@\n Hello world\n-!\n+Goodbye World\n+gOodBYE world\n+\n+Goodbye World',
+        },
+      ],
+    };
+    const stub = sandbox
+      .stub(octokit.pulls, 'listFiles')
+      .resolves(listFilesOfPRResult);
+
+    // tests
+    await getCurrentPulLRequestPatches(octokit, upstream, pullNumber, pageSize);
+    sandbox.assert.calledOnceWithExactly(stub, {
+      owner: upstream.owner,
+      repo: upstream.repo,
+      pull_number: pullNumber,
+      per_page: pageSize,
+    });
+  });
+  it('Returns all the valid patches', async () => {
+    // setup
+    const listFilesOfPRResult = {
+      headers: {},
+      status: 200,
+      url: 'http://fake-url.com',
+      data: [
+        {
+          sha: 'a1d470fa4d7b04450715e3e02d240a34517cd988',
+          filename: 'Readme.md',
+          status: 'modified',
+          additions: 4,
+          deletions: 1,
+          changes: 5,
+          blob_url:
+            'https://github.com/TomKristie/HelloWorld/blob/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+          raw_url:
+            'https://github.com/TomKristie/HelloWorld/raw/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+          contents_url:
+            'https://api.github.com/repos/TomKristie/HelloWorld/contents/Readme.md?ref=eb53f3871f56e8dd6321e44621fe6ac2da1bc120',
+          patch:
+            '@@ -1,2 +1,5 @@\n Hello world\n-!\n+Goodbye World\n+gOodBYE world\n+\n+Goodbye World',
+        },
+        {
+          sha: '8b137891791fe96927ad78e64b0aad7bded08bdc',
+          filename: 'foo/foo.txt',
+          status: 'modified',
+          additions: 1,
+          deletions: 1,
+          changes: 2,
+          blob_url:
+            'https://github.com/TomKristie/HelloWorld/blob/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/foo/foo.txt',
+          raw_url:
+            'https://github.com/TomKristie/HelloWorld/raw/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/foo/foo.txt',
+          contents_url:
+            'https://api.github.com/repos/TomKristie/HelloWorld/contents/foo/foo.txt?ref=eb53f3871f56e8dd6321e44621fe6ac2da1bc120',
+          patch: '@@ -1 +1 @@\n-Hello foo\n+',
+        },
+        {
+          sha: '3b18e512dba79e4c8300dd08aeb37f8e728b8dad',
+          filename: 'helloworld.txt',
+          status: 'removed',
+          additions: 0,
+          deletions: 1,
+          changes: 1,
+          blob_url:
+            'https://github.com/TomKristie/HelloWorld/blob/f5da827a725a701302da7db2da16b1678f52fdcc/helloworld.txt',
+          raw_url:
+            'https://github.com/TomKristie/HelloWorld/raw/f5da827a725a701302da7db2da16b1678f52fdcc/helloworld.txt',
+          contents_url:
+            'https://api.github.com/repos/TomKristie/HelloWorld/contents/helloworld.txt?ref=f5da827a725a701302da7db2da16b1678f52fdcc',
+          patch: '@@ -1 +0,0 @@\n-hello world',
+        },
+      ],
+    };
+    sandbox.stub(octokit.pulls, 'listFiles').resolves(listFilesOfPRResult);
+
+    // tests
+    const {patches, filesMissingPatch} = await getCurrentPulLRequestPatches(
+      octokit,
+      upstream,
+      pullNumber,
+      pageSize
+    );
+    expect(patches.size).equals(3);
+    expect(patches.get(listFilesOfPRResult.data[0].filename)).equals(
+      listFilesOfPRResult.data[0].patch
+    );
+    expect(patches.get(listFilesOfPRResult.data[1].filename)).equals(
+      listFilesOfPRResult.data[1].patch
+    );
+    expect(patches.get(listFilesOfPRResult.data[2].filename)).equals(
+      listFilesOfPRResult.data[2].patch
+    );
+    expect(filesMissingPatch.length).equals(0);
+  });
+  it('Passes the error message up from octokit when octokit fails', async () => {
+    // setup
+    const errorMsg = 'Error message';
+    sandbox.stub(octokit.pulls, 'listFiles').rejects(Error(errorMsg));
+    try {
+      await getCurrentPulLRequestPatches(
+        octokit,
+        upstream,
+        pullNumber,
+        pageSize
+      );
+      expect.fail(
+        'The getCurrentPulLRequestPatches function should have failed because Octokit failed.'
+      );
+    } catch (err) {
+      expect(err.message).to.equal(errorMsg);
+    }
+  });
+  it('Throws when there is no list file data returned from octokit', async () => {
+    // setup
+    const listFilesOfPRResult = {
+      headers: {},
+      status: 200,
+      url: 'http://fake-url.com',
+      data: [],
+    };
+    sandbox.stub(octokit.pulls, 'listFiles').resolves(listFilesOfPRResult);
+    try {
+      await getCurrentPulLRequestPatches(
+        octokit,
+        upstream,
+        pullNumber,
+        pageSize
+      );
+      expect.fail(
+        'The getCurrentPulLRequestPatches function should have failed because Octokit failed.'
+      );
+    } catch (err) {
+      expect(err.message).to.equal('Empty Pull Request');
+    }
+  });
+  it('Does not error when there is list file data but no patch data', async () => {
+    // setup
+    const listFilesOfPRResult = {
+      headers: {},
+      status: 200,
+      url: 'http://fake-url.com',
+      data: [
+        {
+          sha: 'a1d470fa4d7b04450715e3e02d240a34517cd988',
+          filename: 'Readme.md',
+          status: 'modified',
+          additions: 4,
+          deletions: 1,
+          changes: 5,
+          blob_url:
+            'https://github.com/TomKristie/HelloWorld/blob/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+          raw_url:
+            'https://github.com/TomKristie/HelloWorld/raw/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+          contents_url:
+            'https://api.github.com/repos/TomKristie/HelloWorld/contents/Readme.md?ref=eb53f3871f56e8dd6321e44621fe6ac2da1bc120',
+        },
+      ],
+    };
+
+    /* eslint-disable  @typescript-eslint/no-explicit-any */
+    // these are real results from calling listFiles API and are a valid GitHub return type, but octokit type definition says otherwise
+    // cannot force another type cast since the GitHub API return types are not importable
+    // unknown type cast not allowed
+    const stub = sandbox
+      .stub(logger, 'warn')
+      .resolves(listFilesOfPRResult as any);
+    sandbox
+      .stub(octokit.pulls, 'listFiles')
+      .resolves(listFilesOfPRResult as any);
+
+    // tests
+    const {filesMissingPatch} = await getCurrentPulLRequestPatches(
+      octokit,
+      upstream,
+      pullNumber,
+      pageSize
+    );
+    sandbox.assert.called(stub);
+    expect(filesMissingPatch.length).equals(1);
+    expect(filesMissingPatch[0]).equals(listFilesOfPRResult.data[0].filename);
+  });
+});
+
+describe('Extracting multiple GitHub files ranges from patch text', () => {
+  it('Returns an empty range file record when there is no patch text', () => {
+    const patchText = new Map<string, string>();
+    const ranges = patchTextToRanges(patchText);
+    expect(ranges.size).equals(0);
+  });
+  it('Throws an error when the patch text is an empty string', () => {
+    const patchText = new Map<string, string>();
+    patchText.set('invalid-patch.txt', '');
+    try {
+      patchTextToRanges(patchText);
+    } catch (err) {
+      expect(err.message).equals('Unexpected patch text format');
+    }
+  });
+  it('Throws an error when the patch text is a string that does not contain patch data', () => {
+    const patchText = new Map<string, string>();
+    patchText.set('invalid-patch.txt', '@@ this is some invalid patch data @@');
+    try {
+      patchTextToRanges(patchText);
+    } catch (err) {
+      expect(err.message).equals('Unexpected patch text format');
+    }
+  });
+  it('Calculates ranges with an inclusive lower bound and an exclusive upper bound', () => {
+    const multiline_patch =
+      '@@ -1,2 +1,5 @@\n Hello world\n-!\n+Goodbye World\n+gOodBYE world\n+\n+Goodbye World';
+    const multiline_file_name = 'multi-line-patch.txt';
+    const first_line_patch = "@@ -0,0 +1 @@\n+console.log('Hello World!');";
+    const milti_to_singleline_file_name = 'multi-to-single-line-patch.txt';
+    const patchText = new Map<string, string>();
+    patchText.set(multiline_file_name, multiline_patch);
+    patchText.set(milti_to_singleline_file_name, first_line_patch);
+    const ranges = patchTextToRanges(patchText);
+    expect(ranges.get(multiline_file_name)).not.equals(null);
+    expect(ranges.get(multiline_file_name)?.length).equals(1);
+    expect((ranges.get(multiline_file_name) as Range[])[0].start).equals(1);
+    expect((ranges.get(multiline_file_name) as Range[])[0].end).not.equals(5);
+    expect((ranges.get(multiline_file_name) as Range[])[0].end).equals(6);
+    expect(ranges.get(milti_to_singleline_file_name)).not.equals(null);
+    expect(ranges.get(milti_to_singleline_file_name)?.length).equals(1);
+    expect(
+      (ranges.get(milti_to_singleline_file_name) as Range[])[0].start
+    ).equals(1);
+    expect(
+      (ranges.get(milti_to_singleline_file_name) as Range[])[0].end
+    ).not.equals(1);
+    expect(
+      (ranges.get(milti_to_singleline_file_name) as Range[])[0].end
+    ).equals(2);
+  });
+  it('Returns a single range file record when there is a single multiline patch hunk', () => {
+    const multiline_patch =
+      '@@ -1,2 +1,5 @@\n Hello world\n-!\n+Goodbye World\n+gOodBYE world\n+\n+Goodbye World';
+    const multiline_file_name = 'multi-line-patch.txt';
+    const patchText = new Map<string, string>();
+    patchText.set(multiline_file_name, multiline_patch);
+    const ranges = patchTextToRanges(patchText);
+    expect(ranges.size).equals(1);
+    expect(ranges.get(multiline_file_name)).not.equals(null);
+    expect(ranges.get(multiline_file_name)?.length).equals(1);
+    expect((ranges.get(multiline_file_name) as Range[])[0].start).equals(1);
+    expect((ranges.get(multiline_file_name) as Range[])[0].end).equals(6);
+  });
+  it('Returns a single range file record when there is a single 1 line patch hunk', () => {
+    const first_line_patch = '@@ -1 +1 @@\n-Hello foo\n+';
+    const singleline_file_name = 'single-line-patch.txt';
+    const patchText = new Map<string, string>();
+    patchText.set(singleline_file_name, first_line_patch);
+    const ranges = patchTextToRanges(patchText);
+    expect(ranges.size).equals(1);
+    expect(ranges.get(singleline_file_name)).not.equals(null);
+    expect(ranges.get(singleline_file_name)?.length).equals(1);
+    expect((ranges.get(singleline_file_name) as Range[])[0].start).equals(1);
+    expect((ranges.get(singleline_file_name) as Range[])[0].end).equals(2);
+  });
+  it('Returns a single range file record when there is a single 1 line to multiline line patch hunk', () => {
+    const single_line_to_multiline_format = '@@ -1 +0,0 @@\n-hello world';
+    const singleline_to_multi_file_name = 'single-line-to-multiline-patch.txt';
+    const patchText = new Map<string, string>();
+    patchText.set(
+      singleline_to_multi_file_name,
+      single_line_to_multiline_format
+    );
+    const ranges = patchTextToRanges(patchText);
+    expect(ranges.size).equals(1);
+    expect(ranges.get(singleline_to_multi_file_name)).not.equals(null);
+    expect(ranges.get(singleline_to_multi_file_name)?.length).equals(1);
+    expect(
+      (ranges.get(singleline_to_multi_file_name) as Range[])[0].start
+    ).equals(0);
+    expect(
+      (ranges.get(singleline_to_multi_file_name) as Range[])[0].end
+    ).equals(0);
+  });
+  it('Returns a single range file record when there is a single multiline to 1 line patch hunk', () => {
+    const first_line_patch = "@@ -0,0 +1 @@\n+console.log('Hello World!');";
+    const milti_to_singleline_file_name = 'multi-to-single-line-patch.txt';
+    const patchText = new Map<string, string>();
+    patchText.set(milti_to_singleline_file_name, first_line_patch);
+    const ranges = patchTextToRanges(patchText);
+    expect(ranges.size).equals(1);
+    expect(ranges.get(milti_to_singleline_file_name)).not.equals(null);
+    expect(ranges.get(milti_to_singleline_file_name)?.length).equals(1);
+    expect(
+      (ranges.get(milti_to_singleline_file_name) as Range[])[0].start
+    ).equals(1);
+    expect(
+      (ranges.get(milti_to_singleline_file_name) as Range[])[0].end
+    ).equals(2);
+  });
+  it('Returns a single range file record when there is a single multiline to 1 line patch hunk', () => {
+    const multiple_patches =
+      '@@ -356,6 +356,7 @@ Hello\n Hello\n Hello\n Hello\n+Bye\n Hello\n Hello\n Hello\n@@ -6576,8 +6577,7 @@ Hello\n Hello\n Hello\n Hello\n-Hello\n-Hello\n+Bye\n Hello\n Hello\n Hello';
+    const multiple_patches_file_name = 'multiple-patches.txt';
+    const patchText = new Map<string, string>();
+    patchText.set(multiple_patches_file_name, multiple_patches);
+    const ranges = patchTextToRanges(patchText);
+    expect(ranges.size).equals(1);
+    expect(ranges.get(multiple_patches_file_name)).not.equals(null);
+    expect(ranges.get(multiple_patches_file_name)?.length).equals(2);
+    expect((ranges.get(multiple_patches_file_name) as Range[])[0].start).equals(
+      356
+    );
+    expect((ranges.get(multiple_patches_file_name) as Range[])[0].end).equals(
+      363
+    );
+    expect((ranges.get(multiple_patches_file_name) as Range[])[1].start).equals(
+      6577
+    );
+    expect((ranges.get(multiple_patches_file_name) as Range[])[1].end).equals(
+      6584
+    );
+  });
+});
+
+describe('Getting the pull request files updated patch lines', () => {
+  const upstream = {owner: 'upstream-owner', repo: 'upstream-repo'};
+  const pullNumber = 10;
+  const pageSize = 80;
+  const octokit = new Octokit({});
+  const sandbox = sinon.createSandbox();
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('Returns the correct values when octokit and patch text parsing function execute properly', async () => {
+    // setup
+    const listFilesOfPRResult = {
+      headers: {},
+      status: 200,
+      url: 'http://fake-url.com',
+      data: [
+        {
+          sha: 'a1d470fa4d7b04450715e3e02d240a34517cd988',
+          filename: 'Readme.md',
+          status: 'modified',
+          additions: 4,
+          deletions: 1,
+          changes: 5,
+          blob_url:
+            'https://github.com/TomKristie/HelloWorld/blob/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+          raw_url:
+            'https://github.com/TomKristie/HelloWorld/raw/eb53f3871f56e8dd6321e44621fe6ac2da1bc120/Readme.md',
+          contents_url:
+            'https://api.github.com/repos/TomKristie/HelloWorld/contents/Readme.md?ref=eb53f3871f56e8dd6321e44621fe6ac2da1bc120',
+          patch:
+            '@@ -1,2 +1,5 @@\n Hello world\n-!\n+Goodbye World\n+gOodBYE world\n+\n+Goodbye World',
+        },
+      ],
+    };
+    const stub = sandbox
+      .stub(octokit.pulls, 'listFiles')
+      .resolves(listFilesOfPRResult);
+
+    // tests
+    const {validFileLines, filesMissingPatch} = await getAllValidFileRanges(
+      octokit,
+      upstream,
+      pullNumber,
+      pageSize
+    );
+    sandbox.assert.calledOnceWithExactly(stub, {
+      owner: upstream.owner,
+      repo: upstream.repo,
+      pull_number: pullNumber,
+      per_page: pageSize,
+    });
+    expect(validFileLines.size).equals(1);
+    expect(validFileLines.get('Readme.md')).not.equals(null);
+    expect(validFileLines.get('Readme.md')?.length).equals(1);
+    expect((validFileLines.get('Readme.md') as Range[])[0].start).equals(1);
+    expect((validFileLines.get('Readme.md') as Range[])[0].end).equals(6);
+    expect(filesMissingPatch.length).equals(0);
+  });
+
+  it('Passes up the error when a sub-method fails', async () => {
+    // setup
+    const errorMsg = 'Test error for list files';
+    sandbox.stub(octokit.pulls, 'listFiles').rejects(new Error(errorMsg));
+
+    // tests
+    try {
+      await getAllValidFileRanges(octokit, upstream, pullNumber, pageSize);
+      expect.fail(
+        'The getAllValidFileRanges function should have failed because Octokit failed.'
+      );
+    } catch (err) {
+      expect(err.message).equals(errorMsg);
+    }
+  });
+});

--- a/test/remote-github-patch-text.ts
+++ b/test/remote-github-patch-text.ts
@@ -260,92 +260,89 @@ describe('patchTextToRanges', () => {
     expect(ranges.get('invalid-patch.txt')).equals(undefined);
   });
   it('Calculates ranges with an inclusive lower bound and an exclusive upper bound', () => {
-    const multiline_patch =
+    const multilinePatch =
       '@@ -1,2 +1,5 @@\n Hello world\n-!\n+Goodbye World\n+gOodBYE world\n+\n+Goodbye World';
-    const multiline_file_name = 'multi-line-patch.txt';
-    const first_line_patch = "@@ -0,0 +1 @@\n+console.log('Hello World!');";
-    const milti_to_singleline_file_name = 'multi-to-single-line-patch.txt';
+    const multilineFileName = 'multi-line-patch.txt';
+    const firstLinePatch = "@@ -0,0 +1 @@\n+console.log('Hello World!');";
+    const multiToSingleLineFileName = 'multi-to-single-line-patch.txt';
     const patchText = new Map<string, string>();
-    patchText.set(multiline_file_name, multiline_patch);
-    patchText.set(milti_to_singleline_file_name, first_line_patch);
+    patchText.set(multilineFileName, multilinePatch);
+    patchText.set(multiToSingleLineFileName, firstLinePatch);
     const ranges = patchTextToRanges(patchText);
-    expect(ranges.get(multiline_file_name)).not.equals(null);
-    expect(ranges.get(multiline_file_name)?.length).equals(1);
-    expect(ranges.get(multiline_file_name)![0].start).equals(1);
-    expect(ranges.get(multiline_file_name)![0].end).not.equals(5);
-    expect(ranges.get(multiline_file_name)![0].end).equals(6);
-    expect(ranges.get(milti_to_singleline_file_name)).not.equals(null);
-    expect(ranges.get(milti_to_singleline_file_name)?.length).equals(1);
-    expect(ranges.get(milti_to_singleline_file_name)![0].start).equals(1);
-    expect(ranges.get(milti_to_singleline_file_name)![0].end).not.equals(1);
-    expect(ranges.get(milti_to_singleline_file_name)![0].end).equals(2);
+    expect(ranges.get(multilineFileName)).not.equals(null);
+    expect(ranges.get(multilineFileName)?.length).equals(1);
+    expect(ranges.get(multilineFileName)![0].start).equals(1);
+    expect(ranges.get(multilineFileName)![0].end).not.equals(5);
+    expect(ranges.get(multilineFileName)![0].end).equals(6);
+    expect(ranges.get(multiToSingleLineFileName)).not.equals(null);
+    expect(ranges.get(multiToSingleLineFileName)?.length).equals(1);
+    expect(ranges.get(multiToSingleLineFileName)![0].start).equals(1);
+    expect(ranges.get(multiToSingleLineFileName)![0].end).not.equals(1);
+    expect(ranges.get(multiToSingleLineFileName)![0].end).equals(2);
   });
   it('Returns a single range file record when there is a single multiline patch hunk', () => {
-    const multiline_patch =
+    const multilinePatch =
       '@@ -1,2 +1,5 @@\n Hello world\n-!\n+Goodbye World\n+gOodBYE world\n+\n+Goodbye World';
-    const multiline_file_name = 'multi-line-patch.txt';
+    const multilineFileName = 'multi-line-patch.txt';
     const patchText = new Map<string, string>();
-    patchText.set(multiline_file_name, multiline_patch);
+    patchText.set(multilineFileName, multilinePatch);
     const ranges = patchTextToRanges(patchText);
     expect(ranges.size).equals(1);
-    expect(ranges.get(multiline_file_name)).not.equals(null);
-    expect(ranges.get(multiline_file_name)?.length).equals(1);
-    expect(ranges.get(multiline_file_name)![0].start).equals(1);
-    expect(ranges.get(multiline_file_name)![0].end).equals(6);
+    expect(ranges.get(multilineFileName)).not.equals(null);
+    expect(ranges.get(multilineFileName)?.length).equals(1);
+    expect(ranges.get(multilineFileName)![0].start).equals(1);
+    expect(ranges.get(multilineFileName)![0].end).equals(6);
   });
   it('Returns a single range file record when there is a single 1 line patch hunk', () => {
-    const first_line_patch = '@@ -1 +1 @@\n-Hello foo\n+';
-    const singleline_file_name = 'single-line-patch.txt';
+    const firstLinePatch = '@@ -1 +1 @@\n-Hello foo\n+';
+    const singlelineFIleName = 'single-line-patch.txt';
     const patchText = new Map<string, string>();
-    patchText.set(singleline_file_name, first_line_patch);
+    patchText.set(singlelineFIleName, firstLinePatch);
     const ranges = patchTextToRanges(patchText);
     expect(ranges.size).equals(1);
-    expect(ranges.get(singleline_file_name)).not.equals(null);
-    expect(ranges.get(singleline_file_name)?.length).equals(1);
-    expect(ranges.get(singleline_file_name)![0].start).equals(1);
-    expect(ranges.get(singleline_file_name)![0].end).equals(2);
+    expect(ranges.get(singlelineFIleName)).not.equals(null);
+    expect(ranges.get(singlelineFIleName)?.length).equals(1);
+    expect(ranges.get(singlelineFIleName)![0].start).equals(1);
+    expect(ranges.get(singlelineFIleName)![0].end).equals(2);
   });
   it('Returns a single range file record when there is a single 1 line to multiline line patch hunk', () => {
-    const single_line_to_multiline_format = '@@ -1 +0,0 @@\n-hello world';
-    const singleline_to_multi_file_name = 'single-line-to-multiline-patch.txt';
+    const singleToMultilineFormat = '@@ -1 +0,0 @@\n-hello world';
+    const singleToMultilineFileName = 'single-line-to-multiline-patch.txt';
     const patchText = new Map<string, string>();
-    patchText.set(
-      singleline_to_multi_file_name,
-      single_line_to_multiline_format
-    );
+    patchText.set(singleToMultilineFileName, singleToMultilineFormat);
     const ranges = patchTextToRanges(patchText);
     expect(ranges.size).equals(1);
-    expect(ranges.get(singleline_to_multi_file_name)).not.equals(null);
-    expect(ranges.get(singleline_to_multi_file_name)?.length).equals(1);
-    expect(ranges.get(singleline_to_multi_file_name)![0].start).equals(0);
-    expect(ranges.get(singleline_to_multi_file_name)![0].end).equals(0);
+    expect(ranges.get(singleToMultilineFileName)).not.equals(null);
+    expect(ranges.get(singleToMultilineFileName)?.length).equals(1);
+    expect(ranges.get(singleToMultilineFileName)![0].start).equals(0);
+    expect(ranges.get(singleToMultilineFileName)![0].end).equals(0);
   });
   it('Returns a single range file record when there is a single multiline to 1 line patch hunk', () => {
-    const first_line_patch = "@@ -0,0 +1 @@\n+console.log('Hello World!');";
-    const milti_to_singleline_file_name = 'multi-to-single-line-patch.txt';
+    const firstLinePatch = "@@ -0,0 +1 @@\n+console.log('Hello World!');";
+    const multiToSingleLineFileName = 'multi-to-single-line-patch.txt';
     const patchText = new Map<string, string>();
-    patchText.set(milti_to_singleline_file_name, first_line_patch);
+    patchText.set(multiToSingleLineFileName, firstLinePatch);
     const ranges = patchTextToRanges(patchText);
     expect(ranges.size).equals(1);
-    expect(ranges.get(milti_to_singleline_file_name)).not.equals(null);
-    expect(ranges.get(milti_to_singleline_file_name)?.length).equals(1);
-    expect(ranges.get(milti_to_singleline_file_name)![0].start).equals(1);
-    expect(ranges.get(milti_to_singleline_file_name)![0].end).equals(2);
+    expect(ranges.get(multiToSingleLineFileName)).not.equals(null);
+    expect(ranges.get(multiToSingleLineFileName)?.length).equals(1);
+    expect(ranges.get(multiToSingleLineFileName)![0].start).equals(1);
+    expect(ranges.get(multiToSingleLineFileName)![0].end).equals(2);
   });
   it('Returns a single range file record when there is a single multiline to 1 line patch hunk', () => {
-    const multiple_patches =
+    const multiplePatches =
       '@@ -356,6 +356,7 @@ Hello\n Hello\n Hello\n Hello\n+Bye\n Hello\n Hello\n Hello\n@@ -6576,8 +6577,7 @@ Hello\n Hello\n Hello\n Hello\n-Hello\n-Hello\n+Bye\n Hello\n Hello\n Hello';
-    const multiple_patches_file_name = 'multiple-patches.txt';
+    const multiplePatchesFileName = 'multiple-patches.txt';
     const patchText = new Map<string, string>();
-    patchText.set(multiple_patches_file_name, multiple_patches);
+    patchText.set(multiplePatchesFileName, multiplePatches);
     const ranges = patchTextToRanges(patchText);
     expect(ranges.size).equals(1);
-    expect(ranges.get(multiple_patches_file_name)).not.equals(null);
-    expect(ranges.get(multiple_patches_file_name)?.length).equals(2);
-    expect(ranges.get(multiple_patches_file_name)![0].start).equals(356);
-    expect(ranges.get(multiple_patches_file_name)![0].end).equals(363);
-    expect(ranges.get(multiple_patches_file_name)![1].start).equals(6577);
-    expect(ranges.get(multiple_patches_file_name)![1].end).equals(6584);
+    expect(ranges.get(multiplePatchesFileName)).not.equals(null);
+    expect(ranges.get(multiplePatchesFileName)?.length).equals(2);
+    expect(ranges.get(multiplePatchesFileName)![0].start).equals(356);
+    expect(ranges.get(multiplePatchesFileName)![0].end).equals(363);
+    expect(ranges.get(multiplePatchesFileName)![1].start).equals(6577);
+    expect(ranges.get(multiplePatchesFileName)![1].end).equals(6584);
   });
 });
 

--- a/test/remote-github-patch-text.ts
+++ b/test/remote-github-patch-text.ts
@@ -276,15 +276,9 @@ describe('patchTextToRanges', () => {
     expect(ranges.get(multiline_file_name)![0].end).equals(6);
     expect(ranges.get(milti_to_singleline_file_name)).not.equals(null);
     expect(ranges.get(milti_to_singleline_file_name)?.length).equals(1);
-    expect(
-      ranges.get(milti_to_singleline_file_name)![0].start
-    ).equals(1);
-    expect(
-      ranges.get(milti_to_singleline_file_name)![0].end
-    ).not.equals(1);
-    expect(
-      ranges.get(milti_to_singleline_file_name)![0].end
-    ).equals(2);
+    expect(ranges.get(milti_to_singleline_file_name)![0].start).equals(1);
+    expect(ranges.get(milti_to_singleline_file_name)![0].end).not.equals(1);
+    expect(ranges.get(milti_to_singleline_file_name)![0].end).equals(2);
   });
   it('Returns a single range file record when there is a single multiline patch hunk', () => {
     const multiline_patch =
@@ -323,12 +317,8 @@ describe('patchTextToRanges', () => {
     expect(ranges.size).equals(1);
     expect(ranges.get(singleline_to_multi_file_name)).not.equals(null);
     expect(ranges.get(singleline_to_multi_file_name)?.length).equals(1);
-    expect(
-      ranges.get(singleline_to_multi_file_name)![0].start
-    ).equals(0);
-    expect(
-      ranges.get(singleline_to_multi_file_name)![0].end
-    ).equals(0);
+    expect(ranges.get(singleline_to_multi_file_name)![0].start).equals(0);
+    expect(ranges.get(singleline_to_multi_file_name)![0].end).equals(0);
   });
   it('Returns a single range file record when there is a single multiline to 1 line patch hunk', () => {
     const first_line_patch = "@@ -0,0 +1 @@\n+console.log('Hello World!');";
@@ -339,12 +329,8 @@ describe('patchTextToRanges', () => {
     expect(ranges.size).equals(1);
     expect(ranges.get(milti_to_singleline_file_name)).not.equals(null);
     expect(ranges.get(milti_to_singleline_file_name)?.length).equals(1);
-    expect(
-      ranges.get(milti_to_singleline_file_name)![0].start
-    ).equals(1);
-    expect(
-      ranges.get(milti_to_singleline_file_name)![0].end
-    ).equals(2);
+    expect(ranges.get(milti_to_singleline_file_name)![0].start).equals(1);
+    expect(ranges.get(milti_to_singleline_file_name)![0].end).equals(2);
   });
   it('Returns a single range file record when there is a single multiline to 1 line patch hunk', () => {
     const multiple_patches =
@@ -356,18 +342,10 @@ describe('patchTextToRanges', () => {
     expect(ranges.size).equals(1);
     expect(ranges.get(multiple_patches_file_name)).not.equals(null);
     expect(ranges.get(multiple_patches_file_name)?.length).equals(2);
-    expect(ranges.get(multiple_patches_file_name)![0].start).equals(
-      356
-    );
-    expect(ranges.get(multiple_patches_file_name)![0].end).equals(
-      363
-    );
-    expect(ranges.get(multiple_patches_file_name)![1].start).equals(
-      6577
-    );
-    expect(ranges.get(multiple_patches_file_name)![1].end).equals(
-      6584
-    );
+    expect(ranges.get(multiple_patches_file_name)![0].start).equals(356);
+    expect(ranges.get(multiple_patches_file_name)![0].end).equals(363);
+    expect(ranges.get(multiple_patches_file_name)![1].start).equals(6577);
+    expect(ranges.get(multiple_patches_file_name)![1].end).equals(6584);
   });
 });
 


### PR DESCRIPTION
In order to suggest lines to comment on in a PR, code-suggester needs to know what lines are in-scope. If a line is suggested that does not appear in the PR file hunk, GitHub throws an error. Therefore we will need know each file's patch range for the updated content.

Hence, fetch the remote pull request so that each file's updated patch range is collected: the valid patch ranges.
Some files will not have a patch field returned, usually because the file is too large: invalid files. This is a subset of the total invalid files of that PR. Collect these files as well for future use.

Towards #59 
