### PR TITLE
feat: return the PR created

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "gts": "^2.0.0",
     "jsdoc": "^3.6.4",
     "jsdoc-fresh": "^1.0.1",
-    "jsdoc-region-tag": "^1.0.2",
+    "jsdoc-region-tag": "^1.0.6",
     "linkinator": "^2.0.0",
     "mocha": "^8.0.0",
     "nock": "^13.0.2",

--- a/src/github-handler/pull-request-handler.ts
+++ b/src/github-handler/pull-request-handler.ts
@@ -36,21 +36,20 @@ async function openPullRequest(
   description: Description,
   maintainersCanModify = true,
   upstreamPrimary: string = DEFAULT_PRIMARY
-): Promise<void> {
+): Promise<number> {
   const head = `${origin.owner}:${origin.branch}`;
-  const existingPullRequest =
-    (
-      await octokit.pulls.list({
-        owner: upstream.owner,
-        repo: origin.repo,
-        head,
-      })
-    ).data.findIndex(pr => pr.head.label === head) >= 0;
+  const existingPullRequest = (
+    await octokit.pulls.list({
+      owner: upstream.owner,
+      repo: origin.repo,
+      head,
+    })
+  ).data.find(pr => pr.head.label === head);
   if (existingPullRequest) {
     logger.info(
       `Found existing pull request for reference ${origin.owner}:${origin.branch}. Skipping creating a new pull request.`
     );
-    return;
+    return existingPullRequest.number;
   }
   const pullResponseData = (
     await octokit.pulls.create({
@@ -66,6 +65,7 @@ async function openPullRequest(
   logger.info(
     `Successfully opened pull request available at url: ${pullResponseData.url}.`
   );
+  return pullResponseData.number;
 }
 
 export {openPullRequest};

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ async function createPullRequest(
     logger.info(
       'Empty change set provided. No changes need to be made. Cancelling workflow.'
     );
-    return -1;
+    return 0;
   }
   const gitHubConfigs = addPullRequestDefaults(options);
   logger.info('Starting GitHub PR workflow...');

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,9 @@ async function createPullRequest(
     gitHubConfigs.maintainersCanModify,
     gitHubConfigs.primary
   );
-  logger.info('Finished PR workflow');
+  logger.info(
+    `Successfully opened pull request available at url: ${pullResponseData.url}.`
+  );
   return prNumber;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,9 +117,7 @@ async function createPullRequest(
     gitHubConfigs.maintainersCanModify,
     gitHubConfigs.primary
   );
-  logger.info(
-    `Successfully opened pull request available at url: ${pullResponseData.url}.`
-  );
+  logger.info(`Successfully opened pull request: ${prNumber}.`);
   return prNumber;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ async function createPullRequest(
   changes: Changes | null | undefined,
   options: CreatePullRequestUserOptions,
   loggerOption?: Logger
-): Promise<void> {
+): Promise<number> {
   setupLogger(loggerOption);
   // if null undefined, or the empty map then no changes have been provided.
   // Do not execute GitHub workflow
@@ -63,7 +63,7 @@ async function createPullRequest(
     logger.info(
       'Empty change set provided. No changes need to be made. Cancelling workflow.'
     );
-    return;
+    return -1;
   }
   const gitHubConfigs = addPullRequestDefaults(options);
   logger.info('Starting GitHub PR workflow...');
@@ -109,7 +109,7 @@ async function createPullRequest(
     body: gitHubConfigs.description,
     title: gitHubConfigs.title,
   };
-  await handler.openPullRequest(
+  const prNumber = await handler.openPullRequest(
     octokit,
     upstream,
     originBranch,
@@ -118,6 +118,7 @@ async function createPullRequest(
     gitHubConfigs.primary
   );
   logger.info('Finished PR workflow');
+  return prNumber;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ import * as retry from 'async-retry';
  * @param {Changes | null | undefined} changes A set of changes. The changes may be empty
  * @param {CreatePullRequestUserOptions} options The configuration for interacting with GitHub provided by the user.
  * @param {Logger} logger The logger instance (optional).
- * @returns {Promise<void>} a void promise
+ * @returns {Promise<number>} a void promise
  */
 async function createPullRequest(
   octokit: Octokit,

--- a/test/pr.ts
+++ b/test/pr.ts
@@ -60,7 +60,12 @@ describe('Opening a pull request', async () => {
       .stub(octokit.pulls, 'create')
       .resolves(createPrResponse);
     // tests
-    await openPullRequest(octokit, upstream, origin, description);
+    const number = await openPullRequest(
+      octokit,
+      upstream,
+      origin,
+      description
+    );
     sandbox.assert.calledOnceWithExactly(stub, {
       owner: upstream.owner,
       repo: origin.repo,
@@ -70,6 +75,7 @@ describe('Opening a pull request', async () => {
       body: description.body,
       maintainer_can_modify: true,
     });
+    expect(number).to.equal(1347);
   });
 
   describe('When there are similar refs with pull requests open, the current new and unique ref still opens a pr', async () => {


### PR DESCRIPTION
This allows upstream users of `code-suggester` to take action based on the PR number created.

release-please uses this when identifying PRs that should be closed.