### PR TITLE
feat(logging): allow pino to be configured

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import {
   FileData,
 } from './types';
 import {Octokit} from '@octokit/rest';
-import {Logger} from 'pino';
+import {Logger, LoggerOptions} from 'pino';
 import {logger, setupLogger} from './logger';
 import {addPullRequestDefaults} from './default-options-handler';
 import * as retry from 'async-retry';
@@ -54,7 +54,7 @@ async function createPullRequest(
   octokit: Octokit,
   changes: Changes | null | undefined,
   options: CreatePullRequestUserOptions,
-  loggerOption?: Logger
+  loggerOption?: Logger|LoggerOptions
 ): Promise<number> {
   setupLogger(loggerOption);
   // if null undefined, or the empty map then no changes have been provided.

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ async function createPullRequest(
   octokit: Octokit,
   changes: Changes | null | undefined,
   options: CreatePullRequestUserOptions,
-  loggerOption?: Logger|LoggerOptions
+  loggerOption?: Logger | LoggerOptions
 ): Promise<number> {
   setupLogger(loggerOption);
   // if null undefined, or the empty map then no changes have been provided.

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -16,10 +16,10 @@ import {Logger, Level} from 'pino';
 import * as Pino from 'pino';
 let logger: Logger;
 
-function setupLogger(userLogger?: Logger|Pino.LoggerOptions) {
+function setupLogger(userLogger?: Logger | Pino.LoggerOptions) {
   if (typeof userLogger === 'undefined' || typeof userLogger === 'object') {
-    logger = Pino(userLogger)
-  } else if (typeof userLogger === 'function') {
+    logger = Pino(userLogger);
+  } else {
     logger = userLogger as Logger;
   }
 }

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -16,8 +16,12 @@ import {Logger, Level} from 'pino';
 import * as Pino from 'pino';
 let logger: Logger;
 
-function setupLogger(userLogger: Logger = Pino()) {
-  logger = userLogger;
+function setupLogger(userLogger?: Logger|Pino.LoggerOptions) {
+  if (typeof userLogger === 'undefined' || typeof userLogger === 'object') {
+    logger = Pino(userLogger)
+  } else if (typeof userLogger === 'function') {
+    logger = userLogger as Logger;
+  }
 }
 
 export {logger, Logger, Level, setupLogger};


### PR DESCRIPTION
Allow pino to be configured with an options object, rather than requiring that upstream libraries pass in an instantiated logger instance.