### PR TITLE
feat: make forking functionality optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The `createPullRequest()` method creates a GitHub Pull request with the files gi
 |   primary	      |   `string`	| The primary upstream branch to open a PR against. Default is `'master'`.   |
 |   message     	|   `string`	| The commit message for the changes. Default is `'code suggestions'`. We recommend following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).|
 |   force	        |   `boolean`	| Whether or not to force push the reference even if the ancestor commits differs. Default is `false`. |
-|   fork	        |   `boolean`	| Whether or not code suggestion should be made from a fork `true` (forking does not work when using `secrets.GITHUB_TOKEN` in an action). |
+|   fork	        |   `boolean`	| Whether or not code suggestion should be made from a fork, defaults to `true` (_Note: forking does not work when using `secrets.GITHUB_TOKEN` in an action_). |
 
 #### `logger`
 *[Logger](https://www.npmjs.com/package/@types/pino)* <br>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm i code-suggester
 
 ### Example
 
-```
+```js
 const suggester = require("code-suggester");
 
 async function main() {
@@ -89,8 +89,7 @@ The `createPullRequest()` method creates a GitHub Pull request with the files gi
 |   primary	      |   `string`	| The primary upstream branch to open a PR against. Default is `'master'`.   |
 |   message     	|   `string`	| The commit message for the changes. Default is `'code suggestions'`. We recommend following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).|
 |   force	        |   `boolean`	| Whether or not to force push the reference even if the ancestor commits differs. Default is `false`. |
-
-
+|   fork	        |   `boolean`	| Whether or not code suggestion should be made from a fork `true` (forking does not work when using `secrets.GITHUB_TOKEN` in an action). |
 
 #### `logger`
 *[Logger](https://www.npmjs.com/package/@types/pino)* <br>

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,8 @@ async function createPullRequest(
     owner: gitHubConfigs.upstreamOwner,
     repo: gitHubConfigs.upstreamRepo,
   };
-  const origin: RepoDomain = await handler.fork(octokit, upstream);
+  const origin: RepoDomain =
+    options.fork === false ? upstream : await handler.fork(octokit, upstream);
   const originBranch: BranchDomain = {
     ...origin,
     branch: gitHubConfigs.branch,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,6 +87,8 @@ export interface CreatePullRequestUserOptions {
   branch?: string;
   // Whether or not to force branch reference updates. Default is false. (optional)
   force?: boolean;
+  // Should a fork be used when creating pull request
+  fork?: boolean;
   // Primary upstream branch to open PRs against. Default is 'master' (optional)
   primary?: string;
   // Whether or not maintainers can modify the PR. Default is true. (optional)

--- a/test/main-make-pr.ts
+++ b/test/main-make-pr.ts
@@ -126,7 +126,7 @@ describe('Make PR main function', () => {
   it('does not create fork when fork is false', async () => {
     const stubHelperHandlers = {
       fork: (octokit: Octokit, upstream: {owner: string; repo: string}) => {
-        // throw Error('should not call fork');
+        throw Error('should not call fork');
       },
       branch: (
         octokit: Octokit,


### PR DESCRIPTION
If you are using `secrets.GITHUB_TOKEN` or an application JWT, there's no associated GitHub account to fork to.

This feature adds the option to skip forking in these contexts.