### PR TITLE
refactor(action): compile action from current checkout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,15 @@
 # limitations under the License.
 
 FROM node:12
-RUN npm install code-suggester -g
+
 RUN apt-get -y install git
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod u+x /entrypoint.sh
-ENTRYPOINT  ["/entrypoint.sh"]
+
+RUN mkdir -p /workspace
+COPY . /workspace
+WORKDIR /workspace
+RUN npm install && \
+    npm run compile && \
+    npm link && \
+    chmod u+x entrypoint.sh
+
+ENTRYPOINT  ["/workspace/entrypoint.sh"]

--- a/action.yaml
+++ b/action.yaml
@@ -54,15 +54,3 @@ inputs:
 runs:
   using: docker
   image: Dockerfile
-  args:
-    - ${{ inputs.command }}
-    - ${{ inputs.upstream_repo }}
-    - ${{ inputs.upstream_owner }}
-    - ${{ inputs.description }}
-    - ${{ inputs.title }}
-    - ${{ inputs.branch }}
-    - ${{ inputs.primary }}
-    - ${{ inputs.message }}
-    - ${{ inputs.force }}
-    - ${{ inputs.maintainers_can_modify }}
-    - ${{ inputs.git_dir }}


### PR DESCRIPTION
You should use the code-suggester library at the tagged version of the action rather than whatever is the latest stable version on npm.