### PR TITLE
feat(framework-core): return review number and variable renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,21 @@ and suggestions whose diff hunk is a subset of the pull request's files hunks.
  If the program terminates without exception, a timeline comment will be made with all errors or suggestions that could not be made.
 
 #### Syntax
-`reviewPullRequest(octokit, rawChanges, config [, logger])`
+`reviewPullRequest(octokit, diffContents, config [, logger])`
 
 #### Parameters
 #### `octokit`
 *octokit* <br>
 **Required.** An authenticated [octokit](https://github.com/octokit/rest.js/) instance.
 
-#### `rawChanges`
-*Map<string, RawContent> | null | undefined* <br>
-**Required.** A set of files with their respective original raw file content and the new file content. If it is null, the empty map, or undefined, a review is not made.
+#### `diffContents`
+*Map<string, FileDiffContent> | null | undefined* <br>
+**Required.** A set of files with their respective original text file content and the new file content.
+If the map is null, the empty map, or undefined, a review is not made.
+A review is also not made when forall FileDiffContent objects, f,
+f.oldContent == f.newContent
 
-**RawContent Object**
+**FileDiffContent Object**
 |      field      |     type  	|   description	|
 |---------------	|-----------	|-------------	|
 |   oldContent	|   `string`	| **Required.** The older version of a file.  |
@@ -98,6 +101,8 @@ and suggestions whose diff hunk is a subset of the pull request's files hunks.
 *[Logger](https://www.npmjs.com/package/@types/pino)* <br>
 The default logger is [Pino](https://github.com/pinojs/pino). You can plug in any logger that conforms to [Pino's interface](https://www.npmjs.com/package/@types/pino)
 
+#### returns
+returns the review number if a review was created, or null if a review was not made and an exception was not thrown.
 
 #### Exceptions
 The core-library will throw an exception if the [GitHub V3 API](https://developer.github.com/v3/) returns an error response, or if the response data format did not come back as expected. <br>

--- a/src/github-handler/comment-handler/raw-patch-handler/hunk-to-patch-handler.ts
+++ b/src/github-handler/comment-handler/raw-patch-handler/hunk-to-patch-handler.ts
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Hunk, Patch, RawContent} from '../../../types';
+import {Hunk, Patch, FileDiffContent} from '../../../types';
 
 /**
  * From the each file's hunk, generate each file's hunk's old version range
  * and the new content (from the user's) to update that range with.
  * @param filesHunks a list of hunks for each file where the lines are at least 1
- * @param rawChanges
+ * @param diffContents
  * @returns patches to upload to octokit
  */
 export function generatePatches(
   filesHunks: Map<string, Hunk[]>,
-  rawChanges: Map<string, RawContent>
+  diffContents: Map<string, FileDiffContent>
 ): Map<string, Patch[]> {
   const filesPatches: Map<string, Patch[]> = new Map();
   filesHunks.forEach((hunks, fileName) => {
@@ -31,7 +31,7 @@ export function generatePatches(
     // we expect all hunk lists to not be empty
     hunks.forEach(hunk => {
       // returns a copy of the hashmap value, then creates a new list with new substrings
-      const lines = rawChanges.get(fileName)!.newContent.split('\n');
+      const lines = diffContents.get(fileName)!.newContent.split('\n');
       // creates a new shallow-copied subarray
       // we assume the hunk new start and new end to be within the domain of the lines length
       if (

--- a/src/github-handler/comment-handler/raw-patch-handler/in-scope-hunks-handler.ts
+++ b/src/github-handler/comment-handler/raw-patch-handler/in-scope-hunks-handler.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Hunk, Range, RawContent} from '../../../types';
+import {Hunk, Range, FileDiffContent} from '../../../types';
 import {getRawSuggestionHunks} from './raw-hunk-handler';
 
 /**
@@ -165,19 +165,19 @@ export function mergeOutOfScopeSuggestions(
 
 /**
  * Get the in scope (of the corresponding pull request's) hunks and files
- * @param {Map<string, RawContent>} rawChanges the raw old content and new content of a file
+ * @param {Map<string, FileDiffContent>} diffContents the old text content and new text content of a file
  * @param {string[]} invalidFiles list of invalid files
  * @param {Map<string, Range[]>} validFileLines a map of each file's in scope lines for a Pull Request
  */
 export function getValidSuggestionHunks(
-  rawChanges: Map<string, RawContent>,
+  diffContents: Map<string, FileDiffContent>,
   invalidFiles: string[],
   validFileLines: Map<string, Range[]>
 ): {
   inScopeSuggestions: Map<string, Hunk[]>;
   outOfScopeSuggestions: Map<string, Hunk[]>;
 } {
-  const totalfileHunks = getRawSuggestionHunks(rawChanges);
+  const totalfileHunks = getRawSuggestionHunks(diffContents);
   const outofScopeByFilename = getOutOfScopeByFileName(
     invalidFiles,
     totalfileHunks

--- a/src/github-handler/comment-handler/raw-patch-handler/index.ts
+++ b/src/github-handler/comment-handler/raw-patch-handler/index.ts
@@ -14,7 +14,7 @@
 
 import {generatePatches} from './hunk-to-patch-handler';
 import {getValidSuggestionHunks} from './in-scope-hunks-handler';
-import {Hunk, RawContent, Range, Patch} from '../../../types';
+import {Hunk, FileDiffContent, Range, Patch} from '../../../types';
 
 interface SuggestionPatches {
   filePatches: Map<string, Patch[]>;
@@ -25,23 +25,23 @@ interface SuggestionPatches {
  * Get the range of the old version of every file and the corresponding new text for that range
  * whose old and new contents differ, under the constraints that the file
  * is in scope for Pull Request, as well as its lines.
- * @param {Map<string, RawContent>} rawChanges the raw old content and new content of a file
+ * @param {Map<string, FileDiffContent>} diffContents the old text content and new text content of a file
  * @param {string[]} invalidFiles list of invalid files
  * @param {Map<string, Range[]>} validFileLines a map of each file's in scope lines for a Pull Request
  */
 export function getSuggestionPatches(
-  rawChanges: Map<string, RawContent>,
+  diffContents: Map<string, FileDiffContent>,
   invalidFiles: string[],
   validFileLines: Map<string, Range[]>
 ): SuggestionPatches {
   const {inScopeSuggestions, outOfScopeSuggestions} = getValidSuggestionHunks(
-    rawChanges,
+    diffContents,
     invalidFiles,
     validFileLines
   );
   const filePatches: Map<string, Patch[]> = generatePatches(
     inScopeSuggestions,
-    rawChanges
+    diffContents
   );
   return {filePatches, outOfScopeSuggestions};
 }

--- a/src/github-handler/comment-handler/raw-patch-handler/raw-hunk-handler.ts
+++ b/src/github-handler/comment-handler/raw-patch-handler/raw-hunk-handler.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Hunk, RawContent} from '../../../types';
+import {Hunk, FileDiffContent} from '../../../types';
 import {logger} from '../../../logger';
 import {structuredPatch, Hunk as RawHunk} from 'diff';
 
@@ -20,19 +20,19 @@ import {structuredPatch, Hunk as RawHunk} from 'diff';
  * Given the old content and new content of a file
  * compute the diff and extract the necessary hunk data.
  * The hunk list is a list of disjoint ascending intervals.
- * @param rawContent
+ * @param fileDiffContent
  * @param fileName
  * @returns the hunks that are generated in ascending sorted order
  */
 export function generateHunks(
-  rawContent: RawContent,
+  fileDiffContent: FileDiffContent,
   fileName: string
 ): Hunk[] {
   const rawHunks: RawHunk[] = structuredPatch(
     fileName, // old file name
     fileName, // new file name
-    rawContent.oldContent,
-    rawContent.newContent
+    fileDiffContent.oldContent,
+    fileDiffContent.newContent
   ).hunks;
   const hunks: Hunk[] = rawHunks.map(rawHunk => ({
     oldStart: rawHunk.oldStart,
@@ -49,19 +49,19 @@ export function generateHunks(
  * compute the hunk for each file whose old and new contents differ.
  * Do not compute the hunk if the old content is the same as the new content.
  * The hunk list is sorted and each interval is disjoint.
- * @param {Map<string, RawContent>} rawChanges a map of the original file contents and the new file contents
+ * @param {Map<string, FileDiffContent>} diffContents a map of the original file contents and the new file contents
  * @returns the hunks for each file whose old and new contents differ
  */
 export function getRawSuggestionHunks(
-  rawChanges: Map<string, RawContent>
+  diffContents: Map<string, FileDiffContent>
 ): Map<string, Hunk[]> {
   const fileHunks: Map<string, Hunk[]> = new Map();
-  rawChanges.forEach((rawContent: RawContent, fileName: string) => {
+  diffContents.forEach((fileDiffContent: FileDiffContent, fileName: string) => {
     // if identical don't calculate the hunk and continue in the loop
-    if (rawContent.oldContent === rawContent.newContent) {
+    if (fileDiffContent.oldContent === fileDiffContent.newContent) {
       return;
     }
-    const hunks = generateHunks(rawContent, fileName);
+    const hunks = generateHunks(fileDiffContent, fileName);
     fileHunks.set(fileName, hunks);
   });
   logger.info('Parsed ranges of old and new patch');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -157,7 +157,7 @@ export class PatchSyntaxError extends Error {
 /**
  * The file content of the original content and the patched content
  */
-export interface RawContent {
+export interface FileDiffContent {
   readonly oldContent: string;
   readonly newContent: string;
 }
@@ -178,7 +178,7 @@ export interface Hunk {
 }
 
 /**
- * The range of a patch along with the raw file content
+ * The range of a patch along with the raw text file content
  */
 export interface Patch extends Range {
   readonly newContent: string;

--- a/test/helper-review-pull-request.ts
+++ b/test/helper-review-pull-request.ts
@@ -15,7 +15,7 @@
 import {assert, expect} from 'chai';
 import {describe, it, before} from 'mocha';
 import {octokit, setup} from './util';
-import {RepoDomain, RawContent, Patch, Hunk} from '../src/types';
+import {RepoDomain, FileDiffContent, Patch, Hunk} from '../src/types';
 import {Octokit} from '@octokit/rest';
 import * as proxyquire from 'proxyquire';
 before(() => {
@@ -23,8 +23,8 @@ before(() => {
 });
 
 describe('reviewPullRequest', () => {
-  const rawChanges: Map<string, RawContent> = new Map();
-  rawChanges.set('src/index.ts', {
+  const diffContents: Map<string, FileDiffContent> = new Map();
+  diffContents.set('src/index.ts', {
     newContent: 'hello world',
     oldContent: 'hello',
   });
@@ -66,11 +66,11 @@ describe('reviewPullRequest', () => {
         },
         './raw-patch-handler': {
           getSuggestionPatches: (
-            testRawChanges: Map<string, RawContent>,
+            testDiffContents: Map<string, FileDiffContent>,
             testInvalidFiles: string[],
             testValidFileLines: Map<string, Range[]>
           ) => {
-            expect(testRawChanges).equals(rawChanges);
+            expect(testDiffContents).equals(diffContents);
             expect(testInvalidFiles).equals(invalidFiles);
             expect(testValidFileLines).equals(validFileLines);
             numMockedHelpersCalled += 1;
@@ -100,7 +100,7 @@ describe('reviewPullRequest', () => {
       remote,
       pullNumber,
       pageSize,
-      rawChanges
+      diffContents
     );
     expect(numMockedHelpersCalled).equals(3);
   });
@@ -154,7 +154,7 @@ describe('reviewPullRequest', () => {
       remote,
       pullNumber,
       pageSize,
-      rawChanges
+      diffContents
     );
     expect(numMockedHelpersCalled).equals(2);
   });
@@ -189,7 +189,7 @@ describe('reviewPullRequest', () => {
         remote,
         pullNumber,
         pageSize,
-        rawChanges
+        diffContents
       );
       assert.ok(false);
     } catch (err) {
@@ -228,11 +228,11 @@ describe('reviewPullRequest', () => {
         },
         './raw-patch-handler': {
           getSuggestionPatches: (
-            testRawChanges: Map<string, RawContent>,
+            testDiffContents: Map<string, FileDiffContent>,
             testInvalidFiles: string[],
             testValidFileLines: Map<string, Range[]>
           ) => {
-            expect(testRawChanges).equals(rawChanges);
+            expect(testDiffContents).equals(diffContents);
             expect(testInvalidFiles).equals(invalidFiles);
             expect(testValidFileLines).equals(validFileLines);
             numMockedHelpersCalled += 1;
@@ -247,7 +247,7 @@ describe('reviewPullRequest', () => {
         remote,
         pullNumber,
         pageSize,
-        rawChanges
+        diffContents
       );
       assert.ok(false);
     } catch (err) {
@@ -288,11 +288,11 @@ describe('reviewPullRequest', () => {
         },
         './raw-patch-handler': {
           getSuggestionPatches: (
-            testRawChanges: Map<string, RawContent>,
+            testDiffContents: Map<string, FileDiffContent>,
             testInvalidFiles: string[],
             testValidFileLines: Map<string, Range[]>
           ) => {
-            expect(testRawChanges).equals(rawChanges);
+            expect(testDiffContents).equals(diffContents);
             expect(testInvalidFiles).equals(invalidFiles);
             expect(testValidFileLines).equals(validFileLines);
             numMockedHelpersCalled += 1;
@@ -324,7 +324,7 @@ describe('reviewPullRequest', () => {
         remote,
         pullNumber,
         pageSize,
-        rawChanges
+        diffContents
       );
       assert.ok(false);
     } catch (err) {

--- a/test/hunk-to-patch.ts
+++ b/test/hunk-to-patch.ts
@@ -16,14 +16,14 @@ import {expect} from 'chai';
 import {describe, it, before, beforeEach} from 'mocha';
 import {setup} from './util';
 import {generatePatches} from '../src/github-handler/comment-handler/raw-patch-handler/hunk-to-patch-handler';
-import {Hunk, RawContent} from '../src/types';
+import {Hunk, FileDiffContent} from '../src/types';
 
 before(() => {
   setup();
 });
 
 describe('generatePatches', () => {
-  const rawChanges: Map<string, RawContent> = new Map();
+  const diffContents: Map<string, FileDiffContent> = new Map();
   const filesHunks: Map<string, Hunk[]> = new Map();
 
   const fileName1Addition = 'file-1.txt';
@@ -34,12 +34,12 @@ describe('generatePatches', () => {
   const fileNameNonEmtpy = 'file-6.txt';
 
   beforeEach(() => {
-    rawChanges.clear();
+    diffContents.clear();
     filesHunks.clear();
   });
 
   it('Gets the correct substrings when there is 1 addition', () => {
-    rawChanges.set(fileName1Addition, {
+    diffContents.set(fileName1Addition, {
       oldContent:
         'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n',
       newContent:
@@ -48,7 +48,7 @@ describe('generatePatches', () => {
     filesHunks.set(fileName1Addition, [
       {oldStart: 1, oldEnd: 6, newStart: 1, newEnd: 7},
     ]);
-    const filePatches = generatePatches(filesHunks, rawChanges);
+    const filePatches = generatePatches(filesHunks, diffContents);
     expect(filePatches.get(fileName1Addition)!).deep.equals([
       {
         start: 1,
@@ -59,7 +59,7 @@ describe('generatePatches', () => {
   });
 
   it('Gets the correct substrings when there is 2 additions', () => {
-    rawChanges.set(fileName2Addition, {
+    diffContents.set(fileName2Addition, {
       oldContent:
         'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n',
       newContent:
@@ -69,7 +69,7 @@ describe('generatePatches', () => {
       {oldStart: 1, oldEnd: 6, newStart: 1, newEnd: 7},
       {oldStart: 9, oldEnd: 12, newStart: 10, newEnd: 13},
     ]);
-    const filePatches = generatePatches(filesHunks, rawChanges);
+    const filePatches = generatePatches(filesHunks, diffContents);
     expect(filePatches.get(fileName2Addition)!).deep.equals([
       {
         start: 1,
@@ -85,7 +85,7 @@ describe('generatePatches', () => {
   });
 
   it('Gets the correct substrings when there is 1 deletion', () => {
-    rawChanges.set(fileNameDelete, {
+    diffContents.set(fileNameDelete, {
       oldContent:
         'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n',
       newContent:
@@ -94,7 +94,7 @@ describe('generatePatches', () => {
     filesHunks.set(fileNameDelete, [
       {oldStart: 9, oldEnd: 12, newStart: 9, newEnd: 11},
     ]);
-    const filePatches = generatePatches(filesHunks, rawChanges);
+    const filePatches = generatePatches(filesHunks, diffContents);
     expect(filePatches.get(fileNameDelete)!).deep.equals([
       {
         start: 9,
@@ -105,7 +105,7 @@ describe('generatePatches', () => {
   });
 
   it('Gets the correct substrings when there is a special patch char prepending the text', () => {
-    rawChanges.set(fileNameSpecialChar1, {
+    diffContents.set(fileNameSpecialChar1, {
       oldContent:
         'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n',
       newContent:
@@ -115,7 +115,7 @@ describe('generatePatches', () => {
     filesHunks.set(fileNameSpecialChar1, [
       {oldStart: 1, oldEnd: 2, newStart: 1, newEnd: 2},
     ]);
-    const filePatches = generatePatches(filesHunks, rawChanges);
+    const filePatches = generatePatches(filesHunks, diffContents);
     expect(filePatches.get(fileNameSpecialChar1)!).deep.equals([
       {
         start: 1,
@@ -126,7 +126,7 @@ describe('generatePatches', () => {
   });
 
   it('Gets the correct substrings when the file is now an empty string', () => {
-    rawChanges.set(fileNameEmtpy, {
+    diffContents.set(fileNameEmtpy, {
       oldContent: 'line1',
       newContent: '',
     });
@@ -134,7 +134,7 @@ describe('generatePatches', () => {
     filesHunks.set(fileNameEmtpy, [
       {oldStart: 1, oldEnd: 2, newStart: 1, newEnd: 1},
     ]);
-    const filePatches = generatePatches(filesHunks, rawChanges);
+    const filePatches = generatePatches(filesHunks, diffContents);
     expect(filePatches.get(fileNameEmtpy)!).deep.equals([
       {
         start: 1,
@@ -145,7 +145,7 @@ describe('generatePatches', () => {
   });
 
   it('Gets the correct substrings when the empty string file is now has text', () => {
-    rawChanges.set(fileNameNonEmtpy, {
+    diffContents.set(fileNameNonEmtpy, {
       oldContent: '',
       newContent:
         'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n',
@@ -154,7 +154,7 @@ describe('generatePatches', () => {
     filesHunks.set(fileNameNonEmtpy, [
       {oldStart: 1, oldEnd: 1, newStart: 1, newEnd: 12},
     ]);
-    const filePatches = generatePatches(filesHunks, rawChanges);
+    const filePatches = generatePatches(filesHunks, diffContents);
     expect(filePatches.get(fileNameNonEmtpy)!).deep.equals([
       {
         start: 1,
@@ -166,7 +166,7 @@ describe('generatePatches', () => {
   });
 
   it('Throws an error when the new start hunk line is 0', () => {
-    rawChanges.set(fileNameNonEmtpy, {
+    diffContents.set(fileNameNonEmtpy, {
       oldContent: '',
       newContent:
         'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n',
@@ -175,7 +175,7 @@ describe('generatePatches', () => {
       {oldStart: 1, oldEnd: 1, newStart: 0, newEnd: 12},
     ]);
     try {
-      generatePatches(filesHunks, rawChanges);
+      generatePatches(filesHunks, diffContents);
       expect.fail(
         'Should have errored because the new start line is < 1. Value should be >= 1'
       );
@@ -184,7 +184,7 @@ describe('generatePatches', () => {
     }
   });
   it('Throws an error when the new end hunk line is 0', () => {
-    rawChanges.set(fileNameNonEmtpy, {
+    diffContents.set(fileNameNonEmtpy, {
       oldContent: '',
       newContent:
         'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n',
@@ -193,7 +193,7 @@ describe('generatePatches', () => {
       {oldStart: 2, oldEnd: 1, newStart: 1, newEnd: 0},
     ]);
     try {
-      generatePatches(filesHunks, rawChanges);
+      generatePatches(filesHunks, diffContents);
       expect.fail(
         'Should have errored because the new end line is < 1. Value should be >= 1'
       );
@@ -202,7 +202,7 @@ describe('generatePatches', () => {
     }
   });
   it('Throws an error when the old start hunk line is 0', () => {
-    rawChanges.set(fileNameNonEmtpy, {
+    diffContents.set(fileNameNonEmtpy, {
       oldContent: '',
       newContent:
         'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n',
@@ -211,7 +211,7 @@ describe('generatePatches', () => {
       {oldStart: 0, oldEnd: 1, newStart: 1, newEnd: 12},
     ]);
     try {
-      generatePatches(filesHunks, rawChanges);
+      generatePatches(filesHunks, diffContents);
       expect.fail(
         'Should have errored because the old start line is < 1. Value should be >= 1'
       );
@@ -220,7 +220,7 @@ describe('generatePatches', () => {
     }
   });
   it('Throws an error when theold end hunk line is 0', () => {
-    rawChanges.set(fileNameNonEmtpy, {
+    diffContents.set(fileNameNonEmtpy, {
       oldContent: '',
       newContent:
         'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n',
@@ -229,7 +229,7 @@ describe('generatePatches', () => {
       {oldStart: 2, oldEnd: 0, newStart: 1, newEnd: 2},
     ]);
     try {
-      generatePatches(filesHunks, rawChanges);
+      generatePatches(filesHunks, diffContents);
       expect.fail(
         'Should have errored because the old end line is < 1. Value should be >= 1'
       );

--- a/test/main-review-pull-request.ts
+++ b/test/main-review-pull-request.ts
@@ -15,7 +15,7 @@
 import {assert, expect} from 'chai';
 import {describe, it, before} from 'mocha';
 import {octokit, setup} from './util';
-import {CreateReviewComment, RepoDomain, RawContent} from '../src/types';
+import {CreateReviewComment, RepoDomain, FileDiffContent} from '../src/types';
 import {Octokit} from '@octokit/rest';
 import * as proxyquire from 'proxyquire';
 before(() => {
@@ -26,8 +26,8 @@ before(() => {
 // tslint:disable:no-unused-expression
 // .true triggers ts-lint failure, but is valid chai
 describe('reviewPullRequest', () => {
-  const rawChanges: Map<string, RawContent> = new Map();
-  rawChanges.set('src/index.ts', {
+  const diffContents: Map<string, FileDiffContent> = new Map();
+  diffContents.set('src/index.ts', {
     newContent: 'hello world',
     oldContent: 'hello',
   });
@@ -50,20 +50,20 @@ describe('reviewPullRequest', () => {
         remote: RepoDomain,
         testPullNumber: number,
         testPPageSize: number,
-        testChanges: Map<string, RawContent>
+        testDiffContents: Map<string, FileDiffContent>
       ) => {
         expect(remote.owner).equals(owner);
         expect(remote.repo).equals(repo);
         expect(testPullNumber).equals(pullNumber);
         expect(testPPageSize).equals(pageSize);
-        expect(testChanges).equals(rawChanges);
+        expect(testDiffContents).equals(diffContents);
         numMockedHelpersCalled += 1;
       },
     };
     const stubReviewPr = proxyquire.noCallThru()('../src/', {
       './github-handler': stubHelperHandlers,
     });
-    await stubReviewPr.reviewPullRequest(octokit, rawChanges, options);
+    await stubReviewPr.reviewPullRequest(octokit, diffContents, options);
     expect(numMockedHelpersCalled).equals(1);
   });
 
@@ -74,7 +74,7 @@ describe('reviewPullRequest', () => {
         remote: RepoDomain,
         pullNumber: number,
         pageSize: number,
-        testChanges: Map<string, RawContent>
+        testDiffContents: Map<string, FileDiffContent>
       ) => {
         assert.isOk(false);
       },
@@ -92,7 +92,7 @@ describe('reviewPullRequest', () => {
         remote: RepoDomain,
         pullNumber: number,
         pageSize: number,
-        testChanges: Map<string, RawContent>
+        testDiffContents: Map<string, FileDiffContent>
       ) => {
         assert.isOk(false);
       },
@@ -110,7 +110,7 @@ describe('reviewPullRequest', () => {
         remote: RepoDomain,
         pullNumber: number,
         pageSize: number,
-        testChanges: Map<string, RawContent>
+        testDiffContents: Map<string, FileDiffContent>
       ) => {
         assert.isOk(false);
       },
@@ -130,7 +130,7 @@ describe('reviewPullRequest', () => {
         remote: RepoDomain,
         pullNumber: number,
         pageSize: number,
-        testChanges: Map<string, RawContent>
+        testDiffContents: Map<string, FileDiffContent>
       ) => {
         throw Error('Review pull request helper failed');
       },
@@ -139,7 +139,7 @@ describe('reviewPullRequest', () => {
       './github-handler': stubHelperHandlers,
     });
     try {
-      await stubReviewPr.reviewPullRequest(octokit, rawChanges, options);
+      await stubReviewPr.reviewPullRequest(octokit, diffContents, options);
       expect.fail(
         'The main function should have errored because the sub-function failed.'
       );

--- a/test/suggestion-hunk.ts
+++ b/test/suggestion-hunk.ts
@@ -26,9 +26,12 @@ before(() => {
 });
 
 describe('generateHunks', () => {
-  const fileDiffContent: FileDiffContent = {oldContent: 'foo', newContent: 'FOO'};
+  const fileDiffContent: FileDiffContent = {
+    oldContent: 'foo',
+    newContent: 'FOO',
+  };
   const fileName = 'README.md';
-  it('Does not update the user\'s input of text file diffs contents', () => {
+  it("Does not update the user's input of text file diffs contents", () => {
     generateHunks(fileDiffContent, fileName);
     expect(fileDiffContent.oldContent).equals('foo');
     expect(fileDiffContent.newContent).equals('FOO');
@@ -59,7 +62,10 @@ describe('generateHunks', () => {
 
 describe('getRawSuggestionHunks', () => {
   const diffContents: Map<string, FileDiffContent> = new Map();
-  const fileDiffContent1: FileDiffContent = {oldContent: 'foo', newContent: 'FOO'};
+  const fileDiffContent1: FileDiffContent = {
+    oldContent: 'foo',
+    newContent: 'FOO',
+  };
   const fileDiffContent2: FileDiffContent = {
     oldContent:
       'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar',
@@ -71,7 +77,7 @@ describe('getRawSuggestionHunks', () => {
   diffContents.set(fileName1, fileDiffContent1);
   diffContents.set(fileName2, fileDiffContent2);
 
-  it('Does not update the user\'s input of text file diff contents', () => {
+  it("Does not update the user's input of text file diff contents", () => {
     getRawSuggestionHunks(diffContents);
     expect(fileDiffContent1.oldContent).equals('foo');
     expect(fileDiffContent1.newContent).equals('FOO');

--- a/test/suggestion-hunk.ts
+++ b/test/suggestion-hunk.ts
@@ -19,23 +19,23 @@ import {
   generateHunks,
   getRawSuggestionHunks,
 } from '../src/github-handler/comment-handler/raw-patch-handler/raw-hunk-handler';
-import {RawContent} from '../src/types';
+import {FileDiffContent} from '../src/types';
 
 before(() => {
   setup();
 });
 
 describe('generateHunks', () => {
-  const rawContent: RawContent = {oldContent: 'foo', newContent: 'FOO'};
+  const fileDiffContent: FileDiffContent = {oldContent: 'foo', newContent: 'FOO'};
   const fileName = 'README.md';
-  it('Does not update the user raw change input', () => {
-    generateHunks(rawContent, fileName);
-    expect(rawContent.oldContent).equals('foo');
-    expect(rawContent.newContent).equals('FOO');
+  it('Does not update the user\'s input of text file diffs contents', () => {
+    generateHunks(fileDiffContent, fileName);
+    expect(fileDiffContent.oldContent).equals('foo');
+    expect(fileDiffContent.newContent).equals('FOO');
   });
 
   it('Generates the hunks that are produced by the diff library given one file', () => {
-    const hunk = generateHunks(rawContent, fileName);
+    const hunk = generateHunks(fileDiffContent, fileName);
     expect(hunk.length).equals(1);
     expect(hunk[0].oldStart).equals(1);
     expect(hunk[0].oldEnd).equals(2);
@@ -44,7 +44,7 @@ describe('generateHunks', () => {
   });
 
   it('Generates the hunks that are produced by the diff library given one file which was empty but now has content', () => {
-    const addingContentToEmpty: RawContent = {
+    const addingContentToEmpty: FileDiffContent = {
       oldContent: '',
       newContent: 'FOO',
     };
@@ -58,9 +58,9 @@ describe('generateHunks', () => {
 });
 
 describe('getRawSuggestionHunks', () => {
-  const rawChange: Map<string, RawContent> = new Map();
-  const rawContent1: RawContent = {oldContent: 'foo', newContent: 'FOO'};
-  const rawContent2: RawContent = {
+  const diffContents: Map<string, FileDiffContent> = new Map();
+  const fileDiffContent1: FileDiffContent = {oldContent: 'foo', newContent: 'FOO'};
+  const fileDiffContent2: FileDiffContent = {
     oldContent:
       'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar',
     newContent:
@@ -68,31 +68,31 @@ describe('getRawSuggestionHunks', () => {
   };
   const fileName1 = 'README.md';
   const fileName2 = 'bars.txt';
-  rawChange.set(fileName1, rawContent1);
-  rawChange.set(fileName2, rawContent2);
+  diffContents.set(fileName1, fileDiffContent1);
+  diffContents.set(fileName2, fileDiffContent2);
 
-  it('Does not update the user raw change input', () => {
-    getRawSuggestionHunks(rawChange);
-    expect(rawContent1.oldContent).equals('foo');
-    expect(rawContent1.newContent).equals('FOO');
-    expect(rawChange.get(fileName1)!.oldContent).equals('foo');
-    expect(rawChange.get(fileName1)!.newContent).equals('FOO');
-    expect(rawContent2.oldContent).equals(
+  it('Does not update the user\'s input of text file diff contents', () => {
+    getRawSuggestionHunks(diffContents);
+    expect(fileDiffContent1.oldContent).equals('foo');
+    expect(fileDiffContent1.newContent).equals('FOO');
+    expect(diffContents.get(fileName1)!.oldContent).equals('foo');
+    expect(diffContents.get(fileName1)!.newContent).equals('FOO');
+    expect(fileDiffContent2.oldContent).equals(
       'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar'
     );
-    expect(rawContent2.newContent).equals(
+    expect(fileDiffContent2.newContent).equals(
       'foo\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nfoo'
     );
-    expect(rawChange.get(fileName2)!.oldContent).equals(
+    expect(diffContents.get(fileName2)!.oldContent).equals(
       'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar'
     );
-    expect(rawChange.get(fileName2)!.newContent).equals(
+    expect(diffContents.get(fileName2)!.newContent).equals(
       'foo\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nfoo'
     );
   });
 
   it('Generates the hunks that are produced by the diff library for all files that are updated', () => {
-    const fileHunks = getRawSuggestionHunks(rawChange);
+    const fileHunks = getRawSuggestionHunks(diffContents);
     expect(fileHunks.size).equals(2);
     expect(fileHunks.get(fileName1)!.length).equals(1);
     expect(fileHunks.get(fileName1)![0].oldStart).equals(1);
@@ -111,13 +111,13 @@ describe('getRawSuggestionHunks', () => {
   });
 
   it('Does not generate hunks for changes that contain no updates', () => {
-    const sameRawChanges = new Map();
-    sameRawChanges.set('unchanged-1.txt', {oldContent: '', newContent: ''});
-    sameRawChanges.set('unchanged-2.txt', {
+    const samediffContents = new Map();
+    samediffContents.set('unchanged-1.txt', {oldContent: '', newContent: ''});
+    samediffContents.set('unchanged-2.txt', {
       oldContent: 'same',
       newContent: 'same',
     });
-    const fileHunks = getRawSuggestionHunks(sameRawChanges);
+    const fileHunks = getRawSuggestionHunks(samediffContents);
     expect(fileHunks.size).equals(0);
   });
 });

--- a/test/suggestion-patch.ts
+++ b/test/suggestion-patch.ts
@@ -16,7 +16,7 @@ import {expect} from 'chai';
 import {describe, it, before, beforeEach} from 'mocha';
 import {setup} from './util';
 import {getValidSuggestionHunks} from '../src/github-handler/comment-handler/raw-patch-handler/in-scope-hunks-handler';
-import {Range, RawContent} from '../src/types';
+import {Range, FileDiffContent} from '../src/types';
 
 before(() => {
   setup();
@@ -30,21 +30,21 @@ describe('getValidSuggestionHunks', () => {
   const invalidFiles = [invalidFile];
   scope.set(fileName1, [{start: 1, end: 2}]);
   scope.set(fileName2, [{start: 2, end: 11}]);
-  const rawChanges: Map<string, RawContent> = new Map();
+  const diffContents: Map<string, FileDiffContent> = new Map();
 
   beforeEach(() => {
-    rawChanges.clear();
+    diffContents.clear();
   });
 
   it('Finds file hunks that are in scope for the pull request', () => {
-    rawChanges.set(fileName2, {
+    diffContents.set(fileName2, {
       oldContent:
         'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar',
       newContent:
         'bar\nbar\nbar\nbar\nbar\nbar\nfoo\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar',
     });
     const suggestions = getValidSuggestionHunks(
-      rawChanges,
+      diffContents,
       invalidFiles,
       scope
     );
@@ -52,14 +52,14 @@ describe('getValidSuggestionHunks', () => {
   });
 
   it('Excludes file hunks that are not in scope for the pull request', () => {
-    rawChanges.set(fileName1, {
+    diffContents.set(fileName1, {
       oldContent:
         'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nfoo',
       newContent:
         'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nfoo',
     });
     const suggestions = getValidSuggestionHunks(
-      rawChanges,
+      diffContents,
       invalidFiles,
       scope
     );
@@ -67,12 +67,12 @@ describe('getValidSuggestionHunks', () => {
   });
 
   it('Excludes suggestion files that are not in scope because the file is not in scope', () => {
-    rawChanges.set('non-existant-file-that-is-not-invalid.txt', {
+    diffContents.set('non-existant-file-that-is-not-invalid.txt', {
       oldContent: 'foo',
       newContent: 'bar',
     });
     const suggestions = getValidSuggestionHunks(
-      rawChanges,
+      diffContents,
       invalidFiles,
       scope
     );
@@ -80,9 +80,9 @@ describe('getValidSuggestionHunks', () => {
   });
 
   it('Excludes suggestion files that are not in scope because the file is invalid', () => {
-    rawChanges.set(invalidFile, {oldContent: 'foo', newContent: 'bar'});
+    diffContents.set(invalidFile, {oldContent: 'foo', newContent: 'bar'});
     const suggestions = getValidSuggestionHunks(
-      rawChanges,
+      diffContents,
       invalidFiles,
       scope
     );
@@ -90,9 +90,9 @@ describe('getValidSuggestionHunks', () => {
   });
 
   it('Does not include suggestion files that have no change', () => {
-    rawChanges.set(fileName1, {oldContent: 'foo', newContent: 'foo'});
+    diffContents.set(fileName1, {oldContent: 'foo', newContent: 'foo'});
     const suggestions = getValidSuggestionHunks(
-      rawChanges,
+      diffContents,
       invalidFiles,
       scope
     );
@@ -101,38 +101,38 @@ describe('getValidSuggestionHunks', () => {
 
   it('Calculates in scope and out of scope files that are mutually exclusive', () => {
     // in scope hunk
-    rawChanges.set(fileName2, {
+    diffContents.set(fileName2, {
       oldContent:
         'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar',
       newContent:
         'bar\nbar\nbar\nbar\nbar\nbar\nfoo\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar',
     });
     // out of scope hunks
-    rawChanges.set(fileName1, {
+    diffContents.set(fileName1, {
       oldContent:
         'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nfoo',
       newContent:
         'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar',
     });
     // same before and after
-    rawChanges.set('same-before-and-after.text', {
+    diffContents.set('same-before-and-after.text', {
       oldContent:
         'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nfoo',
       newContent:
         'bar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nbar\nfoo',
     });
     // out of scope file name
-    rawChanges.set('non-existant-file-that-is-not-invalid.txt', {
+    diffContents.set('non-existant-file-that-is-not-invalid.txt', {
       oldContent: 'foo',
       newContent: 'bar',
     });
     // out of scope file name
-    rawChanges.set(invalidFile, {
+    diffContents.set(invalidFile, {
       oldContent: 'foo',
       newContent: 'bar',
     });
     const suggestions = getValidSuggestionHunks(
-      rawChanges,
+      diffContents,
       invalidFiles,
       scope
     );


### PR DESCRIPTION
Renamed user input for text file content of 'diffs' `rawChanges` to `diffContents`.
Renamed variable name references to this user diff file contents as well, i.e. `testRawContents` -> `testDiffContents`
Renamed `RawContents` object to `FileDiffContents`

Changed return type from void to returning the review number, or null if there was no exception but a review was not created. More succinctly, the return type is `number` and `null`. `null` was chosen since it clearly indicates the "lack-of-existance" of a review.

Moved the logging of successful review into the callee since the `reviewPullRequest` caller method does not always return a number. Having the successful log directly after the corresponding async call was made rather than in the caller allows for better logging control. Now the callee handles the logging of when there are no reviews to be made and when there is a successful review.

Towards #105 
