### PR TITLE
build: remove failing test and refactor test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@octokit/rest": "^18.0.1",
     "@types/yargs": "^15.0.5",
     "async-retry": "^1.3.1",
-    "diff": "^4.0.2",
+    "diff": "^5.0.0",
     "glob": "^7.1.6",
     "parse-diff": "^0.7.1",
     "pino": "^6.3.2",

--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -40,7 +40,8 @@ class InstallationError extends Error {
  * @returns {string} the absolute path relative to the path that the user executed the bash command in
  */
 export function resolvePath(dir: string) {
-  const absoluteDir = path.resolve(process.cwd(), dir);
+  const absoluteDir = path.resolve(__dirname, dir);
+  console.log(`absolute dir in main ${absoluteDir}`)
   return absoluteDir;
 }
 

--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -41,6 +41,7 @@ class InstallationError extends Error {
  */
 export function resolvePath(dir: string) {
   const absoluteDir = path.resolve(process.cwd(), dir);
+  console.log(`absolute directory in main ${absoluteDir}`);
   return absoluteDir;
 }
 

--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -41,6 +41,7 @@ class InstallationError extends Error {
  */
 export function resolvePath(dir: string) {
   const absoluteDir = path.resolve(process.cwd(), dir);
+  console.log(absoluteDir);
   return absoluteDir;
 }
 

--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -40,7 +40,7 @@ class InstallationError extends Error {
  * @returns {string} the absolute path relative to the path that the user executed the bash command in
  */
 export function resolvePath(dir: string) {
-  const absoluteDir = path.resolve(__dirname, dir);
+  const absoluteDir = path.resolve(process.cwd(), dir);
   return absoluteDir;
 }
 

--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -41,7 +41,6 @@ class InstallationError extends Error {
  */
 export function resolvePath(dir: string) {
   const absoluteDir = path.resolve(process.cwd(), dir);
-  console.log(`absolute directory in main ${absoluteDir}`);
   return absoluteDir;
 }
 

--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -41,7 +41,6 @@ class InstallationError extends Error {
  */
 export function resolvePath(dir: string) {
   const absoluteDir = path.resolve(process.cwd(), dir);
-  console.log(absoluteDir);
   return absoluteDir;
 }
 

--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -41,7 +41,6 @@ class InstallationError extends Error {
  */
 export function resolvePath(dir: string) {
   const absoluteDir = path.resolve(__dirname, dir);
-  console.log(`absolute dir in main ${absoluteDir}`)
   return absoluteDir;
 }
 

--- a/test/git-dir-handler.ts
+++ b/test/git-dir-handler.ts
@@ -116,17 +116,8 @@ describe('Repository root', () => {
 });
 
 describe('Path resolving', () => {
-  const absoluteGitDirLinux = path.join(process.cwd(), 'test/fixtures');
-  const absoluteGitDirDos = path.join(process.cwd(), '\\test\\fixtures');
-
-  it("Resolves to absolute path when '..' is a prefix", () => {
-    const relativeGitDir = '../code-suggester/test/fixtures';
-    const path = resolvePath(relativeGitDir);
-    console.log(`path in test ${relativeGitDir}`);
-    console.log(`absoluteGitDirLinux in test ${absoluteGitDirLinux}`);
-    console.log(`absoluteGitDirDos in test ${absoluteGitDirDos}`);
-    expect(path === absoluteGitDirLinux || path === absoluteGitDirDos).true;
-  });
+  const absoluteGitDirLinux = path.resolve(__dirname, 'test/fixtures');
+  const absoluteGitDirDos = path.resolve(__dirname, '\\test\\fixtures');
 
   it("Resolves to absolute path when './' is a prefix", () => {
     const relativeGitDir = './test/fixtures';

--- a/test/git-dir-handler.ts
+++ b/test/git-dir-handler.ts
@@ -122,6 +122,9 @@ describe('Path resolving', () => {
   it("Resolves to absolute path when '..' is a prefix", () => {
     const relativeGitDir = '../code-suggester/test/fixtures';
     const path = resolvePath(relativeGitDir);
+    console.log(`path in test ${relativeGitDir}`);
+    console.log(`absoluteGitDirLinux in test ${absoluteGitDirLinux}`);
+    console.log(`absoluteGitDirDos in test ${absoluteGitDirDos}`);
     expect(path === absoluteGitDirLinux || path === absoluteGitDirDos).true;
   });
 

--- a/test/git-dir-handler.ts
+++ b/test/git-dir-handler.ts
@@ -118,9 +118,12 @@ describe('Path resolving', () => {
   const absoluteGitDirLinux = process.cwd() + '/test/fixtures';
   const absoluteGitDirDos = process.cwd() + '\\test\\fixtures';
 
-  it("Resolves to absolute path when '..' is a prefix", () => {
+  it.only("Resolves to absolute path when '..' is a prefix", () => {
     const relativeGitDir = '../code-suggester/test/fixtures';
     const path = resolvePath(relativeGitDir);
+    console.log(path);
+    console.log(absoluteGitDirDos);
+    console.log(absoluteGitDirLinux);
     expect(path === absoluteGitDirLinux || path === absoluteGitDirDos).true;
   });
 

--- a/test/git-dir-handler.ts
+++ b/test/git-dir-handler.ts
@@ -109,7 +109,7 @@ describe('Repository root', () => {
     findRepoRoot(dir);
     sinon.assert.calledOnceWithExactly(
       stubGitDiff,
-      'git rev-parse --show-toplevel', 
+      'git rev-parse --show-toplevel',
       {cwd: dir}
     );
   });

--- a/test/git-dir-handler.ts
+++ b/test/git-dir-handler.ts
@@ -26,7 +26,6 @@ import * as fs from 'fs';
 import * as sinon from 'sinon';
 import * as child_process from 'child_process';
 import * as path from 'path';
-import { isAbsolute } from 'path';
 
 before(() => {
   setup();
@@ -119,14 +118,14 @@ describe('Repository root', () => {
 describe('Path resolving', () => {
   it("Resolves to absolute path when './' is a prefix", () => {
     const relativeGitDir = './test/fixtures';
-    const path = resolvePath(relativeGitDir);
-    expect(isAbsolute(path)).to.be.true;
+    const testingPath = resolvePath(relativeGitDir);
+    expect(path.isAbsolute(testingPath)).to.be.true;
   });
 
   it('Resolves to absolute path when the leading chars are letters', () => {
     const relativeGitDir = 'test/fixtures';
-    const path = resolvePath(relativeGitDir);
-    expect(isAbsolute(path)).to.be.true;
+    const testingPath = resolvePath(relativeGitDir);
+    expect(path.isAbsolute(testingPath)).to.be.true;
   });
 });
 

--- a/test/git-dir-handler.ts
+++ b/test/git-dir-handler.ts
@@ -26,6 +26,7 @@ import * as fs from 'fs';
 import * as sinon from 'sinon';
 import * as child_process from 'child_process';
 import * as path from 'path';
+import { isAbsolute } from 'path';
 
 before(() => {
   setup();
@@ -109,26 +110,23 @@ describe('Repository root', () => {
     findRepoRoot(dir);
     sinon.assert.calledOnceWithExactly(
       stubGitDiff,
-      'git rev-parse --show-toplevel',
+      'git rev-parse --show-toplevel', 
       {cwd: dir}
     );
   });
 });
 
 describe('Path resolving', () => {
-  const absoluteGitDirLinux = path.resolve(__dirname, 'test/fixtures');
-  const absoluteGitDirDos = path.resolve(__dirname, '\\test\\fixtures');
-
   it("Resolves to absolute path when './' is a prefix", () => {
     const relativeGitDir = './test/fixtures';
     const path = resolvePath(relativeGitDir);
-    expect(path === absoluteGitDirLinux || path === absoluteGitDirDos).true;
+    expect(isAbsolute(path)).to.be.true;
   });
 
   it('Resolves to absolute path when the leading chars are letters', () => {
     const relativeGitDir = 'test/fixtures';
     const path = resolvePath(relativeGitDir);
-    expect(path === absoluteGitDirLinux || path === absoluteGitDirDos).true;
+    expect(isAbsolute(path)).to.be.true;
   });
 });
 

--- a/test/git-dir-handler.ts
+++ b/test/git-dir-handler.ts
@@ -25,6 +25,7 @@ import {
 import * as fs from 'fs';
 import * as sinon from 'sinon';
 import * as child_process from 'child_process';
+import * as path from 'path';
 
 before(() => {
   setup();
@@ -115,15 +116,12 @@ describe('Repository root', () => {
 });
 
 describe('Path resolving', () => {
-  const absoluteGitDirLinux = process.cwd() + '/test/fixtures';
-  const absoluteGitDirDos = process.cwd() + '\\test\\fixtures';
+  const absoluteGitDirLinux = path.join(process.cwd(), 'test/fixtures');
+  const absoluteGitDirDos = path.join(process.cwd(), '\\test\\fixtures');
 
-  it.only("Resolves to absolute path when '..' is a prefix", () => {
+  it("Resolves to absolute path when '..' is a prefix", () => {
     const relativeGitDir = '../code-suggester/test/fixtures';
     const path = resolvePath(relativeGitDir);
-    console.log(path);
-    console.log(absoluteGitDirDos);
-    console.log(absoluteGitDirLinux);
     expect(path === absoluteGitDirLinux || path === absoluteGitDirDos).true;
   });
 


### PR DESCRIPTION
This PR deletes the failing test in #154, and refactors the test suite. 

If I'm understanding this test correctly, I think this test is expecting a result that is different from what path.resolve() in Node does.

This test expects that, for path `foo/bar/hello/hi`, if given `process.cwd()` and `../hello/hi` when called from `bar`, it will get `foo/bar/hello/hi`, when in reality it should (correctly) return `foo/hello/hi`.

Given that there haven't been bugs reported, I don't think that the repo's functionality depends on getting an absolute path using `../`, but it should be worth looking out for.

I also think that this whole test suite `describe('Path resolving')` is probably not doing much for testing, given that the function it is checking against is just a wrapper for path.resolve. However, I refactored the tests so that they better described what they were looking to assert (absolute path-ness).