### PR TITLE
fix: add labels to action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -51,6 +51,8 @@ inputs:
     default: true
   pull_number:
     description: Pull Request number to review. Required for "review" command.
+  labels:
+    description: Labels to add to the pull request being opened.
 runs:
   using: docker
   image: Dockerfile


### PR DESCRIPTION
I forgot to add `labels` to the GitHub Action config in #173.