### PR TITLE
chore: enable renovate lock file updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,15 +5,10 @@
   ],
   "pinVersions": false,
   "rebaseStalePrs": true,
-  "schedule": [
-    "after 9am and before 3pm"
-  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "recreateClosed": true
+  },
   "gitAuthor": null,
-  "packageRules": [
-    {
-      "extends": "packages:linters",
-      "groupName": "linters"
-    }
-  ],
   "ignoreDeps": ["typescript"]
 }


### PR DESCRIPTION
With lock files checked into the repo, issues like the one in #181 will pop up unless we use lock file update PRs to let us know it's happening.  This updates the renovate config to give us a weekly lock file update, as well as removing some cruft with linter configs we don't need.