### PR TITLE
feat!: cleanup custom logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -521,36 +521,6 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
-    "@types/pino": {
-      "version": "6.3.7",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.7.tgz",
-      "integrity": "sha512-v7FdDXVEL0Zx1zcCf0cJZMojChnF+O0ujDKV1UdocsLuUhENjdtNIaanCZK1zRELp35x//bI2/IHtYUK0vmRvw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "@types/pino-pretty": "*",
-        "@types/pino-std-serializers": "*",
-        "@types/sonic-boom": "*"
-      }
-    },
-    "@types/pino-pretty": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.0.tgz",
-      "integrity": "sha512-fIZ+VXf9gJoJR4tiiM7G+j/bZkPoZEfFGzA4d8tAWCTpTVyvVaBwnmdLs3wEXYpMjw8eXulrOzNCjmGHT3FgHw==",
-      "dev": true,
-      "requires": {
-        "@types/pino": "*"
-      }
-    },
-    "@types/pino-std-serializers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
-      "integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/proxyquire": {
       "version": "1.3.28",
       "resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz",
@@ -570,15 +540,6 @@
       "dev": true,
       "requires": {
         "@sinonjs/fake-timers": "^7.0.4"
-      }
-    },
-    "@types/sonic-boom": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@types/sonic-boom/-/sonic-boom-0.7.0.tgz",
-      "integrity": "sha512-AfqR0fZMoUXUNwusgXKxcE9DPlHNDHQp6nKYUd4PSRpLobF5CCevSpyTEBcVZreqaWKCnGBr9KI1fHMTttoB7A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/yargs": {
@@ -1039,11 +1000,6 @@
       "requires": {
         "retry": "0.12.0"
       }
-    },
-    "atomic-sleep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -2026,16 +1982,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-redact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w=="
-    },
-    "fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
-    },
     "fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -2113,11 +2059,6 @@
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
       }
-    },
-    "flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "flatted": {
       "version": "3.1.1",
@@ -3764,24 +3705,6 @@
       "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
       "dev": true
     },
-    "pino": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.3.tgz",
-      "integrity": "sha512-drPtqkkSf0ufx2gaea3TryFiBHdNIdXKf5LN0hTM82SXI4xVIve2wLwNg92e1MT6m3jASLu6VO7eGY6+mmGeyw==",
-      "requires": {
-        "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.7",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
-        "quick-format-unescaped": "^4.0.3",
-        "sonic-boom": "^1.0.2"
-      }
-    },
-    "pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
-    },
     "pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -3922,11 +3845,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
-    },
-    "quick-format-unescaped": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
-      "integrity": "sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg=="
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -4393,15 +4311,6 @@
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
-      }
-    },
-    "sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-      "requires": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
       }
     },
     "source-list-map": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "diff": "^5.0.0",
     "glob": "^7.1.6",
     "parse-diff": "^0.8.0",
-    "pino": "^6.3.2",
     "yargs": "^16.0.0"
   },
   "devDependencies": {
@@ -58,7 +57,6 @@
     "@types/diff": "^5.0.0",
     "@types/mocha": "^8.0.0",
     "@types/node": "^14.0.20",
-    "@types/pino": "^6.3.0",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^10.0.0",
     "c8": "^7.0.1",

--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -84,7 +84,7 @@ function parseGitDiff(
     const relativePath = statusAndPath[1];
     return {oldMode, newMode, status, relativePath};
   } catch (err) {
-    logger.warning(
+    logger.warn(
       `\`git diff --raw\` may have changed formats: \n ${gitDiffPattern}`
     );
     throw err;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,10 +22,10 @@ import {
   FileData,
   FileDiffContent,
   CreateReviewCommentUserOptions,
+  Logger,
 } from './types';
 export {Changes} from './types';
 import {Octokit} from '@octokit/rest';
-import {Logger, LoggerOptions} from 'pino';
 import {logger, setupLogger} from './logger';
 import {
   addPullRequestDefaults,
@@ -54,7 +54,7 @@ export async function reviewPullRequest(
   octokit: Octokit,
   diffContents: Map<string, FileDiffContent> | string,
   options: CreateReviewCommentUserOptions,
-  loggerOption?: Logger | LoggerOptions
+  loggerOption?: Logger
 ): Promise<number | null> {
   setupLogger(loggerOption);
   // if null undefined, or the empty map then no changes have been provided.
@@ -111,7 +111,7 @@ async function createPullRequest(
   octokit: Octokit,
   changes: Changes | null | undefined,
   options: CreatePullRequestUserOptions,
-  loggerOption?: Logger | LoggerOptions
+  loggerOption?: Logger
 ): Promise<number> {
   setupLogger(loggerOption);
   // if null undefined, or the empty map then no changes have been provided.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Logger, Level} from 'pino';
+import {Logger} from './types';
 import * as Pino from 'pino';
 let logger: Logger;
 
-function setupLogger(userLogger?: Logger | Pino.LoggerOptions) {
-  if (typeof userLogger === 'undefined' || typeof userLogger === 'object') {
-    logger = Pino(userLogger);
+function defaultLogger(): Logger {
+  return Pino();
+}
+
+function setupLogger(userLogger?: Logger) {
+  if (userLogger) {
+    logger = userLogger;
   } else {
-    logger = userLogger as Logger;
+    logger = defaultLogger();
   }
 }
 
-export {logger, Logger, Level, setupLogger};
+export {logger, setupLogger};

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,18 +13,21 @@
 // limitations under the License.
 
 import {Logger} from './types';
-import * as Pino from 'pino';
 let logger: Logger;
 
-function defaultLogger(): Logger {
-  return Pino();
+class NullLogger implements Logger {
+  error = () => {};
+  warn = () => {};
+  info = () => {};
+  debug = () => {};
+  trace = () => {};
 }
 
 function setupLogger(userLogger?: Logger) {
   if (userLogger) {
     logger = userLogger;
   } else {
-    logger = defaultLogger();
+    logger = new NullLogger();
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,3 +175,11 @@ export interface Hunk {
   readonly previousLine?: string;
   readonly nextLine?: string;
 }
+
+interface LogFn {
+  /* tslint:disable:no-unnecessary-generics */
+  <T extends object>(obj: T, msg?: string, ...args: any[]): void;
+  (msg: string, ...args: any[]): void;
+}
+
+export type Logger = { [key: string]: LogFn };

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,9 +177,16 @@ export interface Hunk {
 }
 
 interface LogFn {
-  /* tslint:disable:no-unnecessary-generics */
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   <T extends object>(obj: T, msg?: string, ...args: any[]): void;
   (msg: string, ...args: any[]): void;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
 }
 
-export type Logger = { [key: string]: LogFn };
+export interface Logger {
+  error: LogFn;
+  warn: LogFn;
+  info: LogFn;
+  debug: LogFn;
+  trace: LogFn;
+}

--- a/test/util.ts
+++ b/test/util.ts
@@ -15,7 +15,6 @@
 import {setupLogger, logger} from '../src/logger';
 import {Octokit} from '@octokit/rest';
 import {disableNetConnect} from 'nock';
-import * as Pino from 'pino';
 
 const octokit = new Octokit();
 
@@ -24,7 +23,7 @@ const octokit = new Octokit();
  */
 function setup() {
   disableNetConnect();
-  setupLogger(Pino({level: 'warn'}));
+  setupLogger(console);
 }
 
 export {logger, octokit, setup};


### PR DESCRIPTION
This changes the logger option provided to `reviewPullRequest()` and `createPullRequest()` to be a custom `Logger` interface that `code-suggester` declares:

```ts
interface LogFn {
  /* eslint-disable @typescript-eslint/no-explicit-any */
  <T extends object>(obj: T, msg?: string, ...args: any[]): void;
  (msg: string, ...args: any[]): void;
  /* eslint-enable @typescript-eslint/no-explicit-any */
}

export interface Logger {
  error: LogFn;
  warn: LogFn;
  info: LogFn;
  debug: LogFn;
  trace: LogFn;
}
```

* This logger interface can be fulfilled by a default `Pino` logger as well as plain old `console`.
* We now default the logger to a null implementation to keep output to a minimum while allowing for a custom logger if you want output.
* We can drop the `pino` dependency as we now provide a null default logger implementation.

Fixes #178
Fixes #183
