### PR TITLE
refactor!: move custom logger configuration into options

### DIFF
--- a/src/bin/workflow.ts
+++ b/src/bin/workflow.ts
@@ -41,6 +41,7 @@ export function coerceUserCreatePullRequestOptions(): CreatePullRequestUserOptio
     maintainersCanModify: yargs.argv.maintainersCanModify as boolean,
     fork: yargs.argv.fork as boolean,
     labels: yargs.argv.labels as string[],
+    logger,
   };
 }
 
@@ -52,6 +53,7 @@ export function coerceUserCreateReviewRequestOptions(): CreateReviewCommentUserO
     repo: yargs.argv.upstreamRepo as string,
     owner: yargs.argv.upstreamOwner as string,
     pullNumber: yargs.argv.pullNumber as number,
+    logger,
   };
 }
 
@@ -59,14 +61,14 @@ async function createCommand() {
   const options = coerceUserCreatePullRequestOptions();
   const changes = await git.getChanges(yargs.argv['git-dir'] as string);
   const octokit = new Octokit({auth: process.env.ACCESS_TOKEN});
-  await createPullRequest(octokit, changes, options, logger);
+  await createPullRequest(octokit, changes, options);
 }
 
 async function reviewCommand() {
   const reviewOptions = coerceUserCreateReviewRequestOptions();
   const diffContents = await git.getDiffString(yargs.argv['git-dir'] as string);
   const octokit = new Octokit({auth: process.env.ACCESS_TOKEN});
-  await reviewPullRequest(octokit, diffContents, reviewOptions, logger);
+  await reviewPullRequest(octokit, diffContents, reviewOptions);
 }
 
 /**
@@ -74,7 +76,7 @@ async function reviewCommand() {
  */
 export async function main() {
   try {
-    setupLogger();
+    setupLogger(console);
     if (!process.env.ACCESS_TOKEN) {
       throw Error('The ACCESS_TOKEN should not be undefined');
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,16 +47,14 @@ import * as retry from 'async-retry';
  * @param octokit The authenticated octokit instance, instantiated with an access token having permissiong to create a fork on the target repository.
  * @param diffContents A set of changes. The changes may be empty.
  * @param options The configuration for interacting with GitHub provided by the user.
- * @param loggerOption The logger instance (optional).
  * @returns the created review's id number, or null if there are no changes to be made.
  */
 export async function reviewPullRequest(
   octokit: Octokit,
   diffContents: Map<string, FileDiffContent> | string,
-  options: CreateReviewCommentUserOptions,
-  loggerOption?: Logger
+  options: CreateReviewCommentUserOptions
 ): Promise<number | null> {
-  setupLogger(loggerOption);
+  setupLogger(options.logger);
   // if null undefined, or the empty map then no changes have been provided.
   // Do not execute GitHub workflow
   if (
@@ -104,16 +102,14 @@ export async function reviewPullRequest(
  * @param {Octokit} octokit The authenticated octokit instance, instantiated with an access token having permissiong to create a fork on the target repository
  * @param {Changes | null | undefined} changes A set of changes. The changes may be empty
  * @param {CreatePullRequestUserOptions} options The configuration for interacting with GitHub provided by the user.
- * @param {Logger} logger The logger instance (optional).
  * @returns {Promise<number>} the pull request number. Returns 0 if unsuccessful.
  */
 async function createPullRequest(
   octokit: Octokit,
   changes: Changes | null | undefined,
   options: CreatePullRequestUserOptions,
-  loggerOption?: Logger
 ): Promise<number> {
-  setupLogger(loggerOption);
+  setupLogger(options.logger);
   // if null undefined, or the empty map then no changes have been provided.
   // Do not execute GitHub workflow
   if (changes === null || changes === undefined || changes.size === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ import {
   FileData,
   FileDiffContent,
   CreateReviewCommentUserOptions,
-  Logger,
 } from './types';
 export {Changes} from './types';
 import {Octokit} from '@octokit/rest';
@@ -107,7 +106,7 @@ export async function reviewPullRequest(
 async function createPullRequest(
   octokit: Octokit,
   changes: Changes | null | undefined,
-  options: CreatePullRequestUserOptions,
+  options: CreatePullRequestUserOptions
 ): Promise<number> {
   setupLogger(options.logger);
   // if null undefined, or the empty map then no changes have been provided.

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,8 @@ export interface CreatePullRequestUserOptions {
   retry?: number;
   // Create a DRAFT pull request.
   draft?: boolean;
+  // Optional logger to set
+  logger?: Logger;
 }
 
 /**
@@ -137,6 +139,8 @@ export interface CreateReviewCommentUserOptions {
   pullNumber: number;
   // The number of files to return per pull request list files query. Used when getting data on the remote PR's files.
   pageSize?: number;
+  // Optional logger to set
+  logger?: Logger;
 }
 
 /**

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -105,6 +105,7 @@ describe('Mapping pr yargs to create PR options', () => {
       maintainersCanModify: true,
       fork: true,
       labels: ['automerge'],
+      logger: console,
     };
     sandbox.stub(yargs, 'argv').value({_: ['pr'], ...options});
     assert.deepStrictEqual(coerceUserCreatePullRequestOptions(), options);


### PR DESCRIPTION
Options should be made as optional object properties rather than positional arguments.
