### PR TITLE
chore(deps): update to latest lock files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
-      "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
+      "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
       "dev": true
     },
     "@bcoe/v8-coverage": {
@@ -141,13 +141,13 @@
       "dev": true
     },
     "@microsoft/api-documenter": {
-      "version": "7.12.22",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.12.22.tgz",
-      "integrity": "sha512-AETOoj8y4fnZyB9wRfoFIxPzrVc4kLp2t+lk9dBKOkwWKNFJSYEcBeInk4qbQdsAeCG7EyxsbsQRZ+0QfbMNwA==",
+      "version": "7.13.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.13.3.tgz",
+      "integrity": "sha512-K+/CAbpXWSrUkoUMkG5AAnuWI5DdNw22sEnjAYMgD6M7Y+tjV/nBTaGt4UmVl05fWjEN18W9VHIiLttw19bstg==",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor-model": "7.12.5",
-        "@microsoft/tsdoc": "0.12.24",
+        "@microsoft/api-extractor-model": "7.13.0",
+        "@microsoft/tsdoc": "0.13.2",
         "@rushstack/node-core-library": "3.36.2",
         "@rushstack/ts-command-line": "4.7.10",
         "colors": "~1.2.1",
@@ -156,13 +156,14 @@
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.13.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.13.5.tgz",
-      "integrity": "sha512-03RyL5dKn/tbt0Q8DQSFSaiV7nFgrfPElHoYA4QwGORK/7mbGg4kdhXL+UgO55BkSUniTPMe0Vtt1rIyt/3lng==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.14.0.tgz",
+      "integrity": "sha512-R9B0ic8EIcHhwSFQWYTyQX7QDi7kXONeKdIjJI8R+WzVJMA3r0Je9XxSQxxZ9MZIBUxv3fB7pXC2CPIsSkI/BA==",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor-model": "7.12.5",
-        "@microsoft/tsdoc": "0.12.24",
+        "@microsoft/api-extractor-model": "7.13.0",
+        "@microsoft/tsdoc": "0.13.2",
+        "@microsoft/tsdoc-config": "~0.15.2",
         "@rushstack/node-core-library": "3.36.2",
         "@rushstack/rig-package": "0.2.12",
         "@rushstack/ts-command-line": "4.7.10",
@@ -183,20 +184,45 @@
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.12.5.tgz",
-      "integrity": "sha512-oeHZW83JWjIVoCDvdwI5nsZGPxThbq4gZTLAYNeJGZE/mKEO0iayMPGmI3EllJBjwQsFvNVU+O/HGULhB2to/g==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.13.0.tgz",
+      "integrity": "sha512-HnIbXpNiF/a+tTnGVJFq4aaxWEGI5XN7vpm1YjNLc+CY5C0s/bdT0LV9o9NzWSpQdHVUaYhQEVLviaDpusu6dg==",
       "dev": true,
       "requires": {
-        "@microsoft/tsdoc": "0.12.24",
+        "@microsoft/tsdoc": "0.13.2",
+        "@microsoft/tsdoc-config": "~0.15.2",
         "@rushstack/node-core-library": "3.36.2"
       }
     },
     "@microsoft/tsdoc": {
-      "version": "0.12.24",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.24.tgz",
-      "integrity": "sha512-Mfmij13RUTmHEMi9vRUhMXD7rnGR2VvxeNYtaGtaJ4redwwjT4UXYJ+nzmVJF7hhd4pn/Fx5sncDKxMVFJSWPg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.13.2.tgz",
+      "integrity": "sha512-WrHvO8PDL8wd8T2+zBGKrMwVL5IyzR3ryWUsl0PXgEV0QHup4mTLi0QcATefGI6Gx9Anu7vthPyyyLpY0EpiQg==",
       "dev": true
+    },
+    "@microsoft/tsdoc-config": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.15.2.tgz",
+      "integrity": "sha512-mK19b2wJHSdNf8znXSMYVShAHktVr/ib0Ck2FA3lsVBSEhSI/TfXT7DJQkAYgcztTuwazGcg58ZjYdk0hTCVrA==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.13.2",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -267,9 +293,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.0.0.tgz",
-      "integrity": "sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.1.1.tgz",
+      "integrity": "sha512-ICBhnEb+ahi/TTdNuYb/kTyKVBgAM0VD4k6JPzlhJyzt3Z+Tq/bynwCD+gpkJP7AEcNnzC8YO5R39trmzEo2UA=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.13.3",
@@ -285,11 +311,11 @@
       "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz",
-      "integrity": "sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz",
+      "integrity": "sha512-vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==",
       "requires": {
-        "@octokit/types": "^6.13.0",
+        "@octokit/types": "^6.13.1",
         "deprecation": "^2.3.1"
       }
     },
@@ -317,22 +343,22 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.5.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.2.tgz",
-      "integrity": "sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==",
+      "version": "18.5.3",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.3.tgz",
+      "integrity": "sha512-KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==",
       "requires": {
         "@octokit/core": "^3.2.3",
         "@octokit/plugin-paginate-rest": "^2.6.2",
         "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.0.0"
+        "@octokit/plugin-rest-endpoint-methods": "5.0.1"
       }
     },
     "@octokit/types": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
-      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.2.tgz",
+      "integrity": "sha512-jN5LImYHvv7W6SZargq1UMJ3EiaqIz5qkpfsv4GAb4b16SGqctxtOU2TQAZxvsKHkOw2A4zxdsi5wR9en1/ezQ==",
       "requires": {
-        "@octokit/openapi-types": "^6.0.0"
+        "@octokit/openapi-types": "^6.1.1"
       }
     },
     "@rushstack/node-core-library": {
@@ -474,9 +500,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
       "dev": true
     },
     "@types/is-windows": {
@@ -1090,14 +1116,14 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
-      "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
+      "version": "4.16.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
+      "integrity": "sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001208",
+        "caniuse-lite": "^1.0.30001214",
         "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.712",
+        "electron-to-chromium": "^1.3.719",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.71"
       }
@@ -1161,16 +1187,6 @@
         }
       }
     },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      }
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1195,9 +1211,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001210",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001210.tgz",
-      "integrity": "sha512-avmGf0Jo00I8vB0I89J4Pba48kddasErV7slu7wrkyM5uY9gE5P+B+V3hjABv8Hp4YNG2nBqIUFUXlnqNteXEA==",
+      "version": "1.0.30001215",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001215.tgz",
+      "integrity": "sha512-48WKhSpgduUNyY7cHO3lVy7v5Nx2FrvYJrmZjOoQP7w+5dMejWUhjAAszUXioV5UwT2ZWHDEbPgv4sBkd20jDA==",
       "dev": true
     },
     "catharsis": {
@@ -1210,9 +1226,9 @@
       }
     },
     "chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -1590,9 +1606,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.717",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
-      "integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==",
+      "version": "1.3.720",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.720.tgz",
+      "integrity": "sha512-B6zLTxxaOFP4WZm6DrvgRk8kLFYWNhQ5TrHMC0l5WtkMXhU5UbnvWoTfeEwqOruUSlNMhVLfYak7REX6oC5Yfw==",
       "dev": true
     },
     "emoji-regex": {
@@ -1695,9 +1711,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz",
-      "integrity": "sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
+      "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -2148,17 +2164,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      }
-    },
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -2318,12 +2323,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
     },
     "has-yarn": {
@@ -2511,15 +2510,6 @@
         "binary-extensions": "^2.0.0"
       }
     },
-    "is-boolean-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0"
-      }
-    },
     "is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -2530,9 +2520,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
+      "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -2580,12 +2570,6 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
-    "is-number-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
-      "dev": true
-    },
     "is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -2619,12 +2603,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true
-    },
-    "is-string": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
       "dev": true
     },
     "is-typedarray": {
@@ -3443,9 +3421,9 @@
       "dev": true
     },
     "npm-bundled": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
+      "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
       "dev": true,
       "requires": {
         "npm-normalize-package-bin": "^1.0.1"
@@ -4437,20 +4415,18 @@
       }
     },
     "table": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.1.0.tgz",
-      "integrity": "sha512-T4G5KMmqIk6X87gLKWyU5exPpTjLjY5KyrFWaIjv3SvgaIUGXV7UEzGEnZJdTA38/yUS6f9PlKezQ0bYXG3iIQ==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.5.1.tgz",
+      "integrity": "sha512-xGDXWTBJxahkzPQCsn1S9ESHEenU7TbMD5Iv4FeopXv/XwJyWatFjfbor+6ipI10/MNPXBYUamYukOrbPZ9L/w==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
         "lodash.clonedeep": "^4.5.0",
         "lodash.flatten": "^4.4.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -4603,9 +4579,9 @@
       "dev": true
     },
     "ts-loader": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.1.0.tgz",
-      "integrity": "sha512-YiQipGGAFj2zBfqLhp28yUvPP9jUGqHxRzrGYuc82Z2wM27YIHbElXiaZDc93c3x0mz4zvBmS6q/DgExpdj37A==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.2.0.tgz",
+      "integrity": "sha512-ebXBFrNyMSmbWgjnb3WBloUBK+VSx1xckaXsMXxlZRDqce/OPdYBVN5efB0W3V0defq0Gcy4YuzvPGqRgjj85A==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -4804,20 +4780,20 @@
       }
     },
     "webpack": {
-      "version": "5.33.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.33.2.tgz",
-      "integrity": "sha512-X4b7F1sYBmJx8mlh2B7mV5szEkE0jYNJ2y3akgAP0ERi0vLCG1VvdsIxt8lFd4st6SUy0lf7W0CCQS566MBpJg==",
+      "version": "5.35.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.35.1.tgz",
+      "integrity": "sha512-uWKYStqJ23+N6/EnMEwUjPSSKUG1tFmcuKhALEh/QXoUxwN8eb3ATNIZB38A+fO6QZ0xfc7Cu7KNV9LXNhDCsw==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",
-        "@types/estree": "^0.0.46",
+        "@types/estree": "^0.0.47",
         "@webassemblyjs/ast": "1.11.0",
         "@webassemblyjs/wasm-edit": "1.11.0",
         "@webassemblyjs/wasm-parser": "1.11.0",
         "acorn": "^8.0.4",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.7.0",
+        "enhanced-resolve": "^5.8.0",
         "es-module-lexer": "^0.4.0",
         "eslint-scope": "^5.1.1",
         "events": "^3.2.0",
@@ -4835,15 +4811,15 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
-          "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.1.tgz",
+          "integrity": "sha512-z716cpm5TX4uzOzILx8PavOE6C6DKshHDw1aQN52M/yNSqE9s5O8SMfyhCCfCJ3HmTL0NkVOi+8a/55T7YB3bg==",
           "dev": true
         },
         "enhanced-resolve": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
-          "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
+          "version": "5.8.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.0.tgz",
+          "integrity": "sha512-Sl3KRpJA8OpprrtaIswVki3cWPiPKxXuFxJXBp+zNb6s6VwNWwFRUdtmzd2ReUut8n+sCPx7QCtQ7w5wfJhSgQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.4",

--- a/test/branch.ts
+++ b/test/branch.ts
@@ -52,9 +52,7 @@ describe('Branch', () => {
   });
   it('invokes octokit get branch with correct parameters, invokes octokit correctly, and returns the HEAD sha', async () => {
     // setup
-    const branchResponseBody = await import(
-      './fixtures/get-branch-response.json'
-    );
+    const branchResponseBody = require('./fixtures/get-branch-response.json');
     const branchResponse = {
       headers: {},
       status: 200,
@@ -77,9 +75,7 @@ describe('Branch', () => {
 
   it('The create branch function returns the primary SHA when create branching is successful', async () => {
     // setup
-    const branchResponseBody = await import(
-      './fixtures/get-branch-response.json'
-    );
+    const branchResponseBody = require('./fixtures/get-branch-response.json');
     const branchResponse = {
       headers: {},
       status: 200,
@@ -137,9 +133,7 @@ describe('Branch', () => {
 
   it('When there is an existing branch the primary HEAD sha is still returned and no new branch is created', async () => {
     // setup
-    const branchResponseBody = await import(
-      './fixtures/get-branch-response.json'
-    );
+    const branchResponseBody = require('./fixtures/get-branch-response.json');
     const branchResponse = {
       headers: {},
       status: 200,
@@ -191,9 +185,7 @@ describe('Branch', () => {
     );
   });
   it('Branching fails when Octokit list branch fails', async () => {
-    const branchResponseBody = await import(
-      './fixtures/get-branch-response.json'
-    );
+    const branchResponseBody = require('./fixtures/get-branch-response.json');
     const branchResponse = {
       headers: {},
       status: 200,
@@ -209,9 +201,7 @@ describe('Branch', () => {
     );
   });
   it('Branching fails when Octokit create ref fails', async () => {
-    const branchResponseBody = await import(
-      './fixtures/get-branch-response.json'
-    );
+    const branchResponseBody = require('./fixtures/get-branch-response.json');
     const branchResponse = {
       headers: {},
       status: 200,
@@ -230,9 +220,7 @@ describe('Branch', () => {
     );
   });
   it('Branching fails when primary branch specified did not match any of the branches returned', async () => {
-    const branchResponseBody = await import(
-      './fixtures/get-branch-response.json'
-    );
+    const branchResponseBody = require('./fixtures/get-branch-response.json');
     const branchResponse = {
       headers: {},
       status: 200,


### PR DESCRIPTION
The tests in #215 were failing, and this looks to fix things.  This is purposefully moving from `import` to `require` to loosen the type restrictions in the tests. 