### PR TITLE
fix(cli,action): fix unawaited async call

### DIFF
--- a/src/bin/workflow.ts
+++ b/src/bin/workflow.ts
@@ -82,10 +82,10 @@ export async function main() {
     }
     switch (yargs.argv._[0]) {
       case CREATE_PR_COMMAND:
-        createCommand();
+        await createCommand();
         break;
       case REVIEW_PR_COMMAND:
-        reviewCommand();
+        await reviewCommand();
         break;
       default:
         // yargs should have caught this.


### PR DESCRIPTION
The unawaited async call causes the method to not throw, thus we always were returning a `0` exit status.

Fixes #259
