### PR TITLE
fix(cli): don't crash when there are no changes

### DIFF
--- a/src/bin/handle-git-dir-change.ts
+++ b/src/bin/handle-git-dir-change.ts
@@ -147,7 +147,8 @@ export function getAllDiffs(gitRootDir: string): string[] {
   })
     .toString() // strictly return buffer for mocking purposes. sinon ts doesn't infer {encoding: 'utf-8'}
     .trimRight() // remove the trailing new line
-    .split('\n');
+    .split('\n')
+    .filter(line => !!line.trim());
   execSync('git reset .', {cwd: gitRootDir});
   return diffs;
 }


### PR DESCRIPTION
code-suggester CLI is trying to parse an empty string as a valid file diff and crashing.

Fixes #229