### PR TITLE
feat: group commit files into batches

### DIFF
--- a/src/bin/code-suggester.ts
+++ b/src/bin/code-suggester.ts
@@ -97,6 +97,11 @@ yargs
       default: [],
       type: 'array',
     },
+    'files-per-commit': {
+      describe: 'Number of files per commit. Defaults to 100',
+      default: 100,
+      type: 'number',
+    },
   })
   .command(REVIEW_PR_COMMAND, 'Review an open pull request', {
     'upstream-repo': {

--- a/src/bin/workflow.ts
+++ b/src/bin/workflow.ts
@@ -42,6 +42,7 @@ export function coerceUserCreatePullRequestOptions(): CreatePullRequestUserOptio
     fork: yargs.argv.fork as boolean,
     labels: yargs.argv.labels as string[],
     logger,
+    filesPerCommit: yargs.argv.filesPerCommit as number,
   };
 }
 

--- a/src/bin/workflow.ts
+++ b/src/bin/workflow.ts
@@ -62,7 +62,6 @@ async function createCommand() {
   const options = coerceUserCreatePullRequestOptions();
   const changes = await git.getChanges(yargs.argv['git-dir'] as string);
   const octokit = new Octokit({auth: process.env.ACCESS_TOKEN});
-  console.log(options);
   await createPullRequest(octokit, changes, options);
 }
 

--- a/src/bin/workflow.ts
+++ b/src/bin/workflow.ts
@@ -62,6 +62,7 @@ async function createCommand() {
   const options = coerceUserCreatePullRequestOptions();
   const changes = await git.getChanges(yargs.argv['git-dir'] as string);
   const octokit = new Octokit({auth: process.env.ACCESS_TOKEN});
+  console.log(options);
   await createPullRequest(octokit, changes, options);
 }
 

--- a/src/default-options-handler.ts
+++ b/src/default-options-handler.ts
@@ -48,6 +48,7 @@ export function addPullRequestDefaults(
         ? options.primary
         : DEFAULT_PRIMARY_BRANCH,
     maintainersCanModify: options.maintainersCanModify === false ? false : true,
+    filesPerCommit: options.filesPerCommit,
   };
   return pullRequestSettings;
 }

--- a/src/github/commit-and-push.ts
+++ b/src/github/commit-and-push.ts
@@ -22,6 +22,8 @@ import {
 import {Octokit} from '@octokit/rest';
 import {logger} from '../logger';
 
+const DEFAULT_FILES_PER_COMMIT = 100;
+
 /**
  * Generate and return a GitHub tree object structure
  * containing the target change data
@@ -53,6 +55,15 @@ export function generateTreeObjects(changes: Changes): TreeObject[] {
   return tree;
 }
 
+function* inGroupsOf<T>(
+  all: T[],
+  groupSize: number
+): Generator<T[], void, void> {
+  for (let i = 0; i < all.length; i += groupSize) {
+    yield all.slice(i, i + groupSize);
+  }
+}
+
 /**
  * Upload and create a remote GitHub tree
  * and resolves with the new tree SHA.
@@ -67,28 +78,32 @@ export async function createTree(
   octokit: Octokit,
   origin: RepoDomain,
   refHead: string,
-  tree: TreeObject[]
+  tree: TreeObject[],
+  filesPerCommit: number = DEFAULT_FILES_PER_COMMIT
 ): Promise<string> {
-  const oldTreeSha = (
+  let headTreeSha = (
     await octokit.git.getCommit({
       owner: origin.owner,
       repo: origin.repo,
       commit_sha: refHead,
     })
   ).data.tree.sha;
-  logger.info('Got the latest commit tree');
-  const treeSha = (
-    await octokit.git.createTree({
-      owner: origin.owner,
-      repo: origin.repo,
-      tree,
-      base_tree: oldTreeSha,
-    })
-  ).data.sha;
+  logger.info(`Got the latest commit tree: ${headTreeSha}`);
+  for (const treeGroup of inGroupsOf(tree, filesPerCommit)) {
+    logger.debug(`Tree sha: ${headTreeSha}`);
+    headTreeSha = (
+      await octokit.git.createTree({
+        owner: origin.owner,
+        repo: origin.repo,
+        tree: treeGroup,
+        base_tree: headTreeSha,
+      })
+    ).data.sha;
+  }
   logger.info(
-    `Successfully created a tree with the desired changes with SHA ${treeSha}`
+    `Successfully created a tree with the desired changes with SHA ${headTreeSha}`
   );
-  return treeSha;
+  return headTreeSha;
 }
 
 /**
@@ -166,11 +181,18 @@ export async function commitAndPush(
   changes: Changes,
   originBranch: BranchDomain,
   commitMessage: string,
-  force: boolean
+  force: boolean,
+  filesPerCommit: number = DEFAULT_FILES_PER_COMMIT
 ) {
   try {
     const tree = generateTreeObjects(changes);
-    const treeSha = await createTree(octokit, originBranch, refHead, tree);
+    const treeSha = await createTree(
+      octokit,
+      originBranch,
+      refHead,
+      tree,
+      filesPerCommit
+    );
     const commitSha = await createCommit(
       octokit,
       originBranch,

--- a/src/github/create-commit.ts
+++ b/src/github/create-commit.ts
@@ -1,0 +1,48 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Octokit} from '@octokit/rest';
+import {RepoDomain} from '../types';
+import {logger} from '../logger';
+
+/**
+ * Create a commit with a repo snapshot SHA on top of the reference HEAD
+ * and resolves with the SHA of the commit.
+ * Rejects if GitHub V3 API fails with the GitHub error response
+ * @param {Octokit} octokit The authenticated octokit instance
+ * @param {RepoDomain} origin the the remote repository to push changes to
+ * @param {string} refHead the base of the new commit(s)
+ * @param {string} treeSha the tree SHA that this commit will point to
+ * @param {string} message the message of the new commit
+ * @returns {Promise<string>} the new commit SHA
+ */
+export async function createCommit(
+  octokit: Octokit,
+  origin: RepoDomain,
+  refHead: string,
+  treeSha: string,
+  message: string
+): Promise<string> {
+  const commitData = (
+    await octokit.git.createCommit({
+      owner: origin.owner,
+      repo: origin.repo,
+      message,
+      tree: treeSha,
+      parents: [refHead],
+    })
+  ).data;
+  logger.info(`Successfully created commit. See commit at ${commitData.url}`);
+  return commitData.sha;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,8 @@ async function createPullRequest(
     changes,
     originBranch,
     gitHubConfigs.message,
-    gitHubConfigs.force
+    gitHubConfigs.force,
+    gitHubConfigs.filesPerCommit
   );
 
   const description: Description = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,7 @@ async function createPullRequest(
     return 0;
   }
   const gitHubConfigs = addPullRequestDefaults(options);
+  console.log(gitHubConfigs);
   logger.info('Starting GitHub PR workflow...');
   const upstream: RepoDomain = {
     owner: gitHubConfigs.upstreamOwner,

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,6 @@ async function createPullRequest(
     return 0;
   }
   const gitHubConfigs = addPullRequestDefaults(options);
-  console.log(gitHubConfigs);
   logger.info('Starting GitHub PR workflow...');
   const upstream: RepoDomain = {
     owner: gitHubConfigs.upstreamOwner,

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,8 @@ export interface CreatePullRequestUserOptions {
   draft?: boolean;
   // Optional logger to set
   logger?: Logger;
+  // Optional number of files per commit
+  filesPerCommit?: number;
 }
 
 /**
@@ -125,6 +127,8 @@ export interface CreatePullRequest {
   primary: string;
   // Whether or not maintainers can modify the PR.
   maintainersCanModify: boolean;
+  // Optional number of files per commit
+  filesPerCommit?: number;
 }
 
 /**

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -91,6 +91,7 @@ describe('Mapping pr yargs to create PR options', () => {
       fork: true,
       labels: ['automerge'],
       logger: console,
+      filesPerCommit: 100,
     };
     sandbox.stub(yargs, 'argv').value({_: ['pr'], ...options});
     assert.deepStrictEqual(coerceUserCreatePullRequestOptions(), options);

--- a/test/main-pr-option-defaults.ts
+++ b/test/main-pr-option-defaults.ts
@@ -48,6 +48,7 @@ describe('addPullRequestDefaults', () => {
       message: 'chore: custom description',
       primary: 'main',
       maintainersCanModify: true,
+      filesPerCommit: undefined,
     });
     const upstreamAndPrimary: CreatePullRequestUserOptions = {
       upstreamOwner: 'owner',
@@ -68,6 +69,7 @@ describe('addPullRequestDefaults', () => {
       message: 'chore: custom description',
       primary: 'non-default-primary-branch',
       maintainersCanModify: true,
+      filesPerCommit: undefined,
     });
     const upstreamAndPrDescription: CreatePullRequestUserOptions = {
       upstreamOwner: 'owner',
@@ -87,6 +89,7 @@ describe('addPullRequestDefaults', () => {
       message: 'chore: custom code suggestions message',
       primary: 'main',
       maintainersCanModify: true,
+      filesPerCommit: undefined,
     });
   });
   it("Uses all of user's provided options", () => {
@@ -100,6 +103,7 @@ describe('addPullRequestDefaults', () => {
       message: 'chore: code suggestions custom commit message',
       primary: 'non-default-primary-branch',
       maintainersCanModify: false,
+      filesPerCommit: 10,
     };
     const gitHubPr = addPullRequestDefaults(options);
     assert.deepStrictEqual(gitHubPr, options);


### PR DESCRIPTION
Provides a new option for `filesPerCommit` which defaults to 100. If there are more than this limit, `code-suggester` will split into groups of files and make multiple commits. For most use cases, this is a no-op. For larger monorepos, you may see multiple commits.

Fixes #397 

Ran the following command:
```
node build/src/bin/code-suggester.js pr -r code-suggester -o googleapis -t 'testing multiple commits' -d 'testing multiple commits description' -m 'testing multiple commits body' --branch=test-branch --fork=false -f --files-per-commit=3 --git-dir=.
```
with a few test files in my working directory to create: https://github.com/googleapis/code-suggester/pull/401 which has multiple commits.