### PR TITLE
chore: update ci-action workflow

### DIFF
--- a/.github/workflows/ci-action.yaml
+++ b/.github/workflows/ci-action.yaml
@@ -15,7 +15,7 @@ jobs:
       - run: |-
           set -ex
           npm --version
-          npm i
+          npm ci
           npm run compile
           pushd action
           npm ci


### PR DESCRIPTION
I suspect `npm i` causes the recent build failures.

Example failure:
https://github.com/googleapis/code-suggester/actions/runs/3314347076/jobs/5473513904
