### PR TITLE
feat: throw new CommitError if an API error occurs during commit process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3213,9 +3213,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -8520,9 +8520,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "just-extend": {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,21 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export class CommitError extends Error {
+  cause: Error;
+  constructor(message: string, cause: Error) {
+    super(message);
+    this.cause = cause;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {commitAndPush} from './github/commit-and-push';
 import {openPullRequest} from './github/open-pull-request';
 import {addLabels} from './github/labels';
 export {getChanges, getDiffString} from './bin/handle-git-dir-change';
+export {CommitError} from './errors';
 
 /**
  * Given a set of suggestions, make all the multiline inline review comments on a given pull request given
@@ -108,6 +109,7 @@ export async function reviewPullRequest(
  * @param {Changes | null | undefined} changes A set of changes. The changes may be empty
  * @param {CreatePullRequestUserOptions} options The configuration for interacting with GitHub provided by the user.
  * @returns {Promise<number>} the pull request number. Returns 0 if unsuccessful.
+ * @throws {CommitError} on failure during commit process
  */
 async function createPullRequest(
   octokit: Octokit,

--- a/test/commit-and-push.ts
+++ b/test/commit-and-push.ts
@@ -23,6 +23,7 @@ import * as handler from '../src/github/commit-and-push';
 import * as createCommitModule from '../src/github/create-commit';
 import {Changes, FileData, TreeObject, RepoDomain} from '../src/types';
 import {createCommit} from '../src/github/create-commit';
+import {CommitError} from '../src/errors';
 
 type GetCommitResponse = GetResponseTypeFromEndpointMethod<
   typeof octokit.git.getCommit
@@ -353,7 +354,7 @@ describe('Commit and push function', async () => {
       handler.createTree(octokit, origin, '', [
         {path: 'foo.txt', type: 'blob', mode: '100755'},
       ]),
-      error
+      e => e instanceof CommitError && e.cause === error
     );
   });
   it('groups files into batches', async () => {


### PR DESCRIPTION
Towards https://github.com/googleapis/repo-automation-bots/issues/4537

This will allow us to handle this particular class of errors (likely log a warning and ignore). It's easier for us to classify these errors as we throw them rather than trying to get the caller to distinguish which portion of the call to `createPullRequest` failed.
