### PR TITLE
deps: remove jsdoc-fresh devDependency

### DIFF
--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -22,7 +22,6 @@ module.exports = {
   opts: {
     readme: './README.md',
     package: './package.json',
-    template: './node_modules/jsdoc-fresh',
     recurse: true,
     verbose: true,
     destination: './docs/'

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "c8": "^7.0.1",
         "gts": "^3.1.0",
         "jsdoc": "^4.0.0",
-        "jsdoc-fresh": "^2.0.0",
         "jsdoc-region-tag": "^2.0.0",
         "linkinator": "^4.0.0",
         "mocha": "^9.2.2",
@@ -3156,24 +3155,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/jsdoc-fresh": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-fresh/-/jsdoc-fresh-2.0.1.tgz",
-      "integrity": "sha512-2YAPXC6ELBkmFG4wwTUk+lwezFV79c3gO7gCAKiBaNMRLLExSqQHLQkLMF3nZpCZQfrT2mAnb5+jP6GD4gICNg==",
-      "dev": true,
-      "dependencies": {
-        "taffydb": "^2.7.3"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/jsdoc-fresh/node_modules/taffydb": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
-      "integrity": "sha512-GQ3gtYFSOAxSMN/apGtDKKkbJf+8izz5YfbGqIsUc7AMiQOapARZ76dhilRY2h39cynYxBFdafQo5HUL5vgkrg==",
-      "dev": true
     },
     "node_modules/jsdoc-region-tag": {
       "version": "2.0.1",
@@ -8469,23 +8450,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-          "dev": true
-        }
-      }
-    },
-    "jsdoc-fresh": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-fresh/-/jsdoc-fresh-2.0.1.tgz",
-      "integrity": "sha512-2YAPXC6ELBkmFG4wwTUk+lwezFV79c3gO7gCAKiBaNMRLLExSqQHLQkLMF3nZpCZQfrT2mAnb5+jP6GD4gICNg==",
-      "dev": true,
-      "requires": {
-        "taffydb": "^2.7.3"
-      },
-      "dependencies": {
-        "taffydb": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
-          "integrity": "sha512-GQ3gtYFSOAxSMN/apGtDKKkbJf+8izz5YfbGqIsUc7AMiQOapARZ76dhilRY2h39cynYxBFdafQo5HUL5vgkrg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "c8": "^7.0.1",
     "gts": "^3.1.0",
     "jsdoc": "^4.0.0",
-    "jsdoc-fresh": "^2.0.0",
     "jsdoc-region-tag": "^2.0.0",
     "linkinator": "^4.0.0",
     "mocha": "^9.2.2",


### PR DESCRIPTION
Remove dependency on jsdoc-fresh which uses taffydb.
