### PR TITLE
deps: fix handlebars vulnerability by upgrading to 4.7.9

### DIFF
--- a/action/package-lock.json
+++ b/action/package-lock.json
@@ -28,7 +28,6 @@
       }
     },
     "..": {
-      "name": "code-suggester",
       "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -4365,9 +4364,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/action/package.json
+++ b/action/package.json
@@ -44,6 +44,7 @@
     "typescript": "^5.7.3"
   },
   "overrides": {
-    "tmp": "0.2.5"
+    "tmp": "0.2.5",
+    "handlebars": "^4.7.9"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/googleapis/code-suggester/security/dependabot/142.
