### PR TITLE
fix: upgrade tmp to 0.2.6 to resolve path traversal vulnerability

### DIFF
--- a/action/package-lock.json
+++ b/action/package-lock.json
@@ -7448,9 +7448,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/action/package.json
+++ b/action/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.7.3"
   },
   "overrides": {
-    "tmp": "0.2.5",
+    "tmp": "0.2.6",
     "serialize-javascript": "^7.0.5",
     "handlebars": "^4.7.9"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5664,9 +5664,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "webpack-cli": "^5.0.0"
   },
   "overrides": {
-    "tmp": "0.2.5",
+    "tmp": "0.2.6",
     "diff": "^8.0.3",
     "serialize-javascript": "^7.0.5"
   }


### PR DESCRIPTION
Addresses GHSA-ph9p-34f9-6g65.

This PR upgrades the `tmp` dependency override from `0.2.5` to `0.2.6` in both the root project and the `action` subdirectory to resolve a high-severity path traversal vulnerability.

TAG=agy
CONV=6ccca40c-ae16-4bff-a10b-e7f61521a5f1
